### PR TITLE
Fix links to melange.re

### DIFF
--- a/docs/better-burgers/index.md
+++ b/docs/better-burgers/index.md
@@ -40,7 +40,7 @@ a number of syntactic and practical differences between them:
   types.
 
 The runtime representation of a record is a [plain JavaScript
-object](https://melange.re/v3.0.0/communicate-with-javascript/#data-types-and-runtime-representation),
+object](https://melange.re/v3.0.0/communicate-with-javascript.html#data-types-and-runtime-representation),
 the same as for a `Js.t` object.
 
 ::: info

--- a/docs/better-sandwiches/index.md
+++ b/docs/better-sandwiches/index.md
@@ -132,9 +132,9 @@ put shorter branches before longer branches:
 
 ## `{j||j}` quoted string literal
 
-The approach using `Js.Array.join` works, but readability could be improved
-by using a [quoted string literal with the quoted string identifier
-`j`](https://melange.re/v3.0.0/communicate-with-javascript/#strings):
+The approach using `Js.Array.join` works, but readability could be improved by
+using a [quoted string literal with the quoted string identifier
+`j`](https://melange.re/v3.0.0/communicate-with-javascript.html#strings):
 
 <<< Item.re#to-emoji-j-string-literal{5-13}
 
@@ -292,13 +292,13 @@ documentation](https://melange.re/v3.0.0/api/re/melange/Stdlib/Printf/index.html
 
 ## Solutions
 
-<b>1.</b> Add a new `Turducken` constructor to variant type `sandwich` and update
-the `Item.toPrice` and `Item.toEmoji` functions accordingly:
+<b>1.</b> Add a new `Turducken` constructor to variant type `sandwich` and
+update the `Item.toPrice` and `Item.toEmoji` functions accordingly:
 
 <<< Item.re#item-turducken
 
-Of course, you could've chosen a completely different sandwich, and that would be
-just fine.
+Of course, you could've chosen a completely different sandwich, and that would
+be just fine.
 
 <b>2.</b> In the alternate dimension where the turducken sandwich was added,
 Madame Jellobutter wants to do a promotion called "Turducken Tuesdays" where
@@ -318,7 +318,8 @@ this](https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGNvbXB1dGU
 
 View [source
 code](https://github.com/melange-re/melange-for-react-devs/blob/main/src/better-sandwiches/)
-and [demo](https://react-book.melange.re/demo/src/better-sandwiches/) for this chapter.
+and [demo](https://react-book.melange.re/demo/src/better-sandwiches/) for this
+chapter.
 
 -----
 

--- a/docs/celsius-converter-exception/index.md
+++ b/docs/celsius-converter-exception/index.md
@@ -107,7 +107,7 @@ number of decimals in the converted value using
 
 `Js.Float.toFixed` is a function that has one positional argument
 and one [labeled
-argument](https://melange.re/v3.0.0/communicate-with-javascript/#labeled-arguments).
+argument](https://melange.re/v3.0.0/communicate-with-javascript.html#labeled-arguments).
 In this case, the labeled argument is named `digits` and it's receiving a value
 of `2`. It's not possible to pass in the value of a labeled argument without
 using the `~label=value` syntax. We'll see more of labeled arguments in the
@@ -208,7 +208,7 @@ function.
 
 <b>1.</b> Changing it to `"°C = "` will result in a bit of gibberish being
 rendered: "Â°C". We can't rely on OCaml strings to [deal with Unicode
-correctly](https://melange.re/v3.0.0/communicate-with-javascript/#strings), so
+correctly](https://melange.re/v3.0.0/communicate-with-javascript.html#strings), so
 any string that contains non-ASCII text must be delimited using `{js||js}`.
 
 ::: tip
@@ -247,5 +247,5 @@ and [demo](https://react-book.melange.re/demo/src/celsius-converter-exception/) 
 
 [^1]:
     See [Using Js.t
-    objects](https://melange.re/v3.0.0/communicate-with-javascript/#using-jst-objects) for more
+    objects](https://melange.re/v3.0.0/communicate-with-javascript.html#using-js-t-objects) for more
     details.

--- a/docs/celsius-converter-option/index.md
+++ b/docs/celsius-converter-option/index.md
@@ -132,7 +132,7 @@ nesting of conditionals to a minimum and making your code more readable.
 Hooray! Our Celsius converter is finally complete. Later, we'll see how to
 [create a component that can convert back and forth between Celsius and
 Fahrenheit](/todo). But first, we'll explore [Dune, the build
-system](https://melange.re/v3.0.0/build-system/) used by Melange.
+system](https://melange.re/v3.0.0/build-system.html) used by Melange.
 
 ## Exercises
 

--- a/docs/counter/index.md
+++ b/docs/counter/index.md
@@ -43,7 +43,7 @@ comes from the name of the module.
 The `make` function has the type `unit => React.element`, meaning it takes `()`
 as the only argument and returns an object of type `React.element`. You'll need
 to decorate `make` with the
-[attribute](https://melange.re/v3.0.0/communicate-with-javascript/#attributes)
+[attribute](https://melange.re/v3.0.0/communicate-with-javascript.html#attributes)
 `@react.component`. We'll go into the details [later](/todo), but for now
 let's just say that `@react.component` is there to reduce boilerplate and make
 our code more readable and easier to maintain.
@@ -102,7 +102,7 @@ read from left to right:
 {counter |> Int.to_string |> React.string}
 ```
 
-This uses the [pipe last operator](https://melange.re/v3.0.0/communicate-with-javascript/#pipe-last),
+This uses the [pipe last operator](https://melange.re/v3.0.0/communicate-with-javascript.html#pipe-last),
 which is useful for chaining function calls.
 
 ## Basic styling

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -9,7 +9,7 @@ Linux](https://learn.microsoft.com/en-us/windows/wsl/)
   - [Node.js](https://nodejs.org/)
   - [git](https://git-scm.com/)
   - A code editor such as [Visual Studio Code](https://code.visualstudio.com/)
-    - There are also [many other editors](https://melange.re/v3.0.0/getting-started/#editor-integration)
+    - There are also [many other editors](https://melange.re/v3.0.0/getting-started.html#editor-integration)
       which can support OCaml
 
 ## Opam

--- a/docs/intro-to-dune/index.md
+++ b/docs/intro-to-dune/index.md
@@ -73,7 +73,7 @@ the root directory of your project:
  (libraries reason-react)
  ; The `preprocess` field lists preprocessors which transform code before it is
  ; compiled. melange.ppx allows to use Melange attributes [@mel. ...]
- ; (https://melange.re/v2.0.0/communicate-with-javascript/#attributes)
+ ; (https://melange.re/v3.0.0/communicate-with-javascript.html#attributes)
  ; reason-react-ppx allows to use JSX for ReasonReact components by using the
  ; [@JSX] attributes from Reason: https://reasonml.github.io/docs/en/jsx
  (preprocess

--- a/docs/intro-to-dune/index.md
+++ b/docs/intro-to-dune/index.md
@@ -5,7 +5,7 @@ your project. Since these components don't have much in common with each other,
 it makes sense to put them in separate, independent single-page apps. To do
 that, we'll use [Dune](https://dune.build/), a build system designed for OCaml
 projects, with many [useful
-features](https://melange.re/v3.0.0/build-system/#features). For our purposes,
+features](https://melange.re/v3.0.0/build-system.html#features). For our purposes,
 the feature of primary interest is its [built-in support for
 Melange](https://dune.readthedocs.io/en/stable/melange.html).
 
@@ -127,7 +127,7 @@ the `index.html` file in the root directory:
 
 For more details about where JavaScript output files end up in the build
 directory, see [JavaScript artifacts
-layout](https://melange.re/v3.0.0/build-system/#javascript-artifacts-layout).
+layout](https://melange.re/v3.0.0/build-system.html#javascript-artifacts-layout).
 
 ::: tip
 
@@ -253,7 +253,7 @@ every single project.
 ::: info
 
 Melange documentation's [guidelines for
-melange.emit](https://melange.re/v3.0.0/build-system/#guidelines-for-melangeemit)
+melange.emit](https://melange.re/v3.0.0/build-system.html#guidelines-for-melange-emit)
 recommends you put the `melange.emit` stanza in the `dune` file in the project's
 root directory. We are no longer doing that going forward, but this is still
 great advice if your repo only contains a single app!

--- a/docs/numeric-types/index.md
+++ b/docs/numeric-types/index.md
@@ -175,7 +175,7 @@ Js.log(Js.typeof(foo)); // prints "number"
 Js.log(Js.typeof(bar)); // prints "number"
 ```
 
-Refer to the [Melange docs](https://melange.re/v3.0.0/communicate-with-javascript/#data-types-and-runtime-representation)
+Refer to the [Melange docs](https://melange.re/v3.0.0/communicate-with-javascript.html#data-types-and-runtime-representation)
 for a complete rundown of how OCaml types get translated to JavaScript types.
 
 ## Widgets in the Playground

--- a/docs/order-confirmation/index.md
+++ b/docs/order-confirmation/index.md
@@ -178,7 +178,7 @@ If you hover over it, you'll see that it has the type signature
 
 When a JavaScript function has optional arguments, it's common to create
 [multiple OCaml functions that bind to
-it](https://melange.re/v3.0.0/communicate-with-javascript/#approach-1-multiple-external-functions).
+it](https://melange.re/v3.0.0/communicate-with-javascript.html#approach-1-multiple-external-functions).
 We'll discuss this in more detail [later](/todo).
 
 ## Type transformations in JSX

--- a/docs/styling-with-css/index.md
+++ b/docs/styling-with-css/index.md
@@ -18,7 +18,7 @@ Add a new file
 In OCaml, there is no syntax to import from files, because all modules within a
 project are visible to all other modules[^2]. However, we can make use of
 JavaScript's `import` syntax by using the [mel.raw extension
-node](https://melange.re/v2.1.0/communicate-with-javascript/#generate-raw-javascript),
+node](https://melange.re/v3.0.0/communicate-with-javascript.html#generate-raw-javascript),
 which allows us to embed raw JavaScript in our OCaml code. Add the following
 line to the top of `Order.re`:
 
@@ -53,7 +53,7 @@ The problem is that Vite is serving the app from the build directory at
 `order-item.css` file isn't in that build directory.
 
 To solve this, we can add the [runtime_deps
-field](https://melange.re/v2.1.0/build-system/#handling-assets) to our
+field](https://melange.re/v3.0.0/build-system.html#handling-assets) to our
 `melange.emit` stanza in `src/order-confirmation/dune`:
 
 ```clj{7}
@@ -118,7 +118,7 @@ Fortunately, Melange provides a more reliable way to import frontend assets.
 ## Import using `external`
 
 At the top of `Order.re`, replace our first `mel.raw` extension node with an
-[external](https://melange.re/v3.0.0/communicate-with-javascript/#external-functions)
+[external](https://melange.re/v3.0.0/communicate-with-javascript.html#external-functions)
 declaration:
 
 ```reason
@@ -141,9 +141,9 @@ Let's break down the individual parts of the `external` declaration:
 [@mel.module "./order-item.css"] external _css: unit = "default";
 ```
 
-- [mel.module](https://melange.re/v3.0.0/communicate-with-javascript/#using-functions-from-other-javascript-modules)
+- [mel.module](https://melange.re/v3.0.0/communicate-with-javascript.html#using-functions-from-other-javascript-modules)
   is an
-  [attribute](https://melange.re/v3.0.0/communicate-with-javascript/#attributes)
+  [attribute](https://melange.re/v3.0.0/communicate-with-javascript.html#attributes)
   that tells the `external` declaration which module to import from
 - The `external` keyword tells OCaml this is a declaration for a value defined
   outside of OCaml, i.e. it comes from JavaScript[^4]
@@ -203,7 +203,7 @@ inside the `OrderComponent` module, since that's the only place it's used.
 
 We have not seen the last of `external` declarations, as they are the primary
 way in which OCaml interacts with code written in JavaScript. See the [Melange
-docs](https://melange.re/v3.0.0/communicate-with-javascript/#external-functions)
+docs](https://melange.re/v3.0.0/communicate-with-javascript.html#external-functions)
 for more details.
 
 ## Class names must be the same


### PR DESCRIPTION
The url structure of melange.re changed a bit after the migration to vitepress. This PR updates all links to use the new structure, as well as replaces some existing links that were still pointing to 2.1.0 version of the docs.