### PR TITLE
Fix errors in 'cram test' chapter

### DIFF
--- a/docs/burger-discounts/index.md
+++ b/docs/burger-discounts/index.md
@@ -211,7 +211,7 @@ Error: This expression has type float option
        because it is in the left-hand side of a sequence
 ```
 
-When you call a function in OCaml, you have use its return value, unless the
+When you call a function in OCaml, you must use its return value, unless the
 return value is `()` (the [unit
 value](https://reasonml.github.io/docs/en/overview#unit)). However, inside this
 test, we are calling `Discount.getFreeBurger` to test its side effects, so the
@@ -258,7 +258,7 @@ test fails. Part of the output (cleaned up for readability) looks like this:
 ```
 
 This is how Melange maps the original OCaml values to their JavaScript runtime
-values shown by Node test runner:
+values:
 
 | OCaml source | JavaScript runtime |
 |--------------|--------------------|
@@ -407,21 +407,21 @@ using lists, which are a better fit for this problem.
 - Type inference is less effective inside functions that don't call other
   functions. In those cases, you can give the compiler more information:
   - Type annotate the function arguments
-  - Use the full name for value
+  - Use the full name for a value used inside the function
 - The `Stdlib` module is opened by default
 - Records are immutable
-- Use record copy syntax to make copies of records that have different values
-  for some fields
+- Use record copy syntax to copy a record while changing some fields on the
+  copy, e.g. `{...burger, lettuce: true, onions: 3}`
 - OCaml doesn't allow you to ignore the return value of functions (unless the
   value is `()`), so you can use `Stdlib.ignore` to explicitly discard return
   values
 - Runtime representations of common data types:
-  - Variant constructor without argument -> integer
-  - Variant constructor with argument -> JavaScript object
-  - Record -> JavaScript object
-  - Array -> JavaScript array
-  - `None` -> `undefined`
-  - `Some(value)` -> `value`
+  - Variant constructor without argument ⮕ integer
+  - Variant constructor with argument ⮕ JavaScript object
+  - Record ⮕ JavaScript object
+  - Array ⮕ JavaScript array
+  - `None` ⮕ `undefined`
+  - `Some(value)` ⮕ `value`
 - Array facts:
   - Arrays are mutable, just like in JavaScript
   - You can pattern match on arrays of fixed length

--- a/docs/burger-discounts/index.md
+++ b/docs/burger-discounts/index.md
@@ -416,12 +416,12 @@ using lists, which are a better fit for this problem.
   value is `()`), so you can use `Stdlib.ignore` to explicitly discard return
   values
 - Runtime representations of common data types:
-  - Variant constructor without argument ⮕ integer
-  - Variant constructor with argument ⮕ JavaScript object
-  - Record ⮕ JavaScript object
-  - Array ⮕ JavaScript array
-  - `None` ⮕ `undefined`
-  - `Some(value)` ⮕ `value`
+  - Variant constructor without argument → integer
+  - Variant constructor with argument → JavaScript object
+  - Record → JavaScript object
+  - Array → JavaScript array
+  - `None` → `undefined`
+  - `Some(value)` → `value`
 - Array facts:
   - Arrays are mutable, just like in JavaScript
   - You can pattern match on arrays of fixed length

--- a/docs/burger-discounts/index.md
+++ b/docs/burger-discounts/index.md
@@ -143,16 +143,16 @@ It's safe to reuse a single record this way because records are immutable. You
 can pass a record to any function and never worry that its fields might be
 changed by that function.
 
-## Record copy syntax
+## Record spread syntax
 
 Add a new test to `DiscountTests`:
 
 <<< DiscountTests.re#different-price-test
 
-Again, we're reusing the `burger` record, but this time, we use [record copy
+Again, we're reusing the `burger` record, but this time, we use [record spread
 syntax](https://reasonml.github.io/docs/en/record#updating-records-spreading) to
-make copies of `burger` record that have slightly different field values. For
-example,
+make copies of the `burger` record that have slightly different field values.
+For example,
 
 ```reason
 {...burger, tomatoes: true}
@@ -410,8 +410,8 @@ using lists, which are a better fit for this problem.
   - Use the full name for a value used inside the function
 - The `Stdlib` module is opened by default
 - Records are immutable
-- Use record copy syntax to copy a record while changing some fields on the
-  copy, e.g. `{...burger, lettuce: true, onions: 3}`
+- Use record spread syntax to copy a record while changing some fields on the
+  copied record, e.g. `{...burger, lettuce: true, onions: 3}`
 - OCaml doesn't allow you to ignore the return value of functions (unless the
   value is `()`), so you can use `Stdlib.ignore` to explicitly discard return
   values

--- a/docs/cram-tests/index.md
+++ b/docs/cram-tests/index.md
@@ -22,14 +22,6 @@ which means:
 - You can run all tests using a single command that doesn't need to refer to
   individual tests
 
-Before you can write your first cram test, you need to enable cram tests by
-adding this to your `dune-project` file:
-
-```dune
-; Enable cram tests
-(cram enable)
-```
-
 ## `cram` stanza
 
 To add dependencies for your cram tests, you need to add a [cram
@@ -286,7 +278,7 @@ If you kept the `$ npx tree` cram test around, you'll observe that even though
 all build targets attached to `@melange` are dependencies, they aren't copied
 into the sandbox directory. You can change that behavior by adding the
 [expand_aliases_in_sandbox
-stanza](https://dune.readthedocs.io/en/stable/dune-files.html#stanza-expand_aliases_in_sandbox)
+stanza](https://dune.readthedocs.io/en/stable/reference/dune-project/expand_aliases_in_sandbox.html)
 to your `dune-project` file:
 
 ```dune
@@ -308,10 +300,9 @@ Fix the bug in `Item.re`. The `SandwichTests` cram test should pass once more.
 
 ::: warning
 
-Using
-[expand_aliases_in_sandbox](https://dune.readthedocs.io/en/stable/dune-files.html#stanza-expand_aliases_in_sandbox)
-is very convenient, but it may noticeably impact cram test performance. If you
-feel your cram tests are too slow, you should remove it.
+Using `expand_aliases_in_sandbox` is very convenient, but it may noticeably
+impact cram test performance. If you feel your cram tests are too slow, you
+should remove it and go back to putting `.mjs` files in your `cram/deps` field.
 
 :::
 

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -39,7 +39,7 @@ teaches the language from the ground up and goes much deeper into its features.
 | Better Burgers | Support different toppings for burgers by using records | record type, record destructuring, record pattern matching, submodules, wildcard |
 | Sandwich Tests | Add unit tests for sandwich-related logic | opam switch, `opam switch`, `opam install`, `opam list`, `.opam` file, `melange-fest`, `open` module, `module_systems` field, punning, type inference |
 | Cram Tests | Set up cram tests to run your unit tests | cram tests, `cram` stanza, Dune alias, promotion, test output sanitization, sandbox, `expand_aliases_in_sandbox` stanza |
-| Burger Discounts | Implement burger discount logic using arrays | limits of type inference, type annotation of function arguments, full name (asset path), `Stdlib`, record copy syntax, `ignore`, runtime representations of common data types, properties of arrays, override `Array.get` |
+| Burger Discounts | Implement burger discount logic using arrays | limits of type inference, type annotation of function arguments, full name (asset path), `Stdlib`, record spread syntax, `ignore`, runtime representations of common data types, properties of arrays, override `Array.get` |
 
 ...and much more to come!
 

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -39,6 +39,7 @@ teaches the language from the ground up and goes much deeper into its features.
 | Better Burgers | Support different toppings for burgers by using records | record type, record destructuring, record pattern matching, submodules, wildcard |
 | Sandwich Tests | Add unit tests for sandwich-related logic | opam switch, `opam switch`, `opam install`, `opam list`, `.opam` file, `melange-fest`, `open` module, `module_systems` field, punning, type inference |
 | Cram Tests | Set up cram tests to run your unit tests | cram tests, `cram` stanza, Dune alias, promotion, test output sanitization, sandbox, `expand_aliases_in_sandbox` stanza |
+| Burger Discounts | Implement burger discount logic using arrays | limits of type inference, type annotation of function arguments, full name (asset path), `Stdlib`, record copy syntax, `ignore`, runtime representations of common data types, properties of arrays, override `Array.get` |
 
 ...and much more to come!
 

--- a/dune-project
+++ b/dune-project
@@ -8,10 +8,6 @@
 
 (name melange-for-react-devs)
 
-; Enable cram tests
-
-(cram enable)
-
 ; Copy all build targets for an alias into the sandbox
 
 (expand_aliases_in_sandbox)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "preinstall:opam": "opam update",
     "install:opam": "opam install -y . --deps-only --with-test",
     "check-npm-deps": "opam exec opam-check-npm-deps",
-    "init": "opam switch create . 5.1.1 -y --deps-only && npm run install-opam-npm",
+    "init": "opam switch create . 5.1.1 -y --deps-only && npm run install:npm-opam",
     "install:npm-opam": "npm install && npm run install:opam && npm run check-npm-deps",
     "dune": "opam exec -- dune",
     "build": "npm run dune -- build",


### PR DESCRIPTION
Fixes the errors mentioned in https://github.com/melange-re/melange-for-react-devs/issues/35

Also:

- [x] Update 'chapters & topics' table
- [x] Fix init npm script 
- [x] A few fixes to 'burger discounts' chapter 