### PR TITLE
Fix exercises in most recent 3 chapters

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -29,7 +29,7 @@ export default defineConfig({
           { text: 'Counter', link: '/counter/' },
           { text: 'Numeric Types', link: '/numeric-types/' },
           { text: 'Celsius Converter', link: '/celsius-converter-exception/' },
-          { text: 'Celsius Converter using Option', link: '/celsius-converter-option/' },
+          { text: 'Celsius Converter Using Option', link: '/celsius-converter-option/' },
           { text: 'Introduction to Dune', link: '/intro-to-dune/' },
           { text: 'Order Confirmation', link: '/order-confirmation/' },
           { text: 'Styling with CSS', link: '/styling-with-css/' },

--- a/docs/burger-discounts/DiscountTests.re
+++ b/docs/burger-discounts/DiscountTests.re
@@ -120,3 +120,81 @@ test("3 burgers of different price, return Some(15.15)", () =>
      )
 );
 // #endregion three-burgers
+
+// #region half-off-tests
+test("No burger has 1 of every topping, return None", () =>
+  expect
+  |> equal(
+       Discount.getHalfOff([|
+         Hotdog,
+         Sandwich(Portabello),
+         Burger({
+           lettuce: true,
+           tomatoes: true,
+           cheese: 1,
+           onions: 1,
+           bacon: 0,
+         }),
+       |]),
+       None,
+     )
+);
+
+test("One burger has 1 of every topping, return Some(15.425)", () =>
+  expect
+  |> equal(
+       Discount.getHalfOff([|
+         Hotdog,
+         Sandwich(Portabello),
+         Burger({
+           lettuce: true,
+           tomatoes: true,
+           cheese: 1,
+           onions: 1,
+           bacon: 1,
+         }),
+       |]),
+       Some(15.425),
+     )
+);
+// #endregion half-off-tests
+
+// #region new-half-off-tests
+module HalfOff = {
+  test("No burger has 1+ of every topping, return None", () =>
+    expect
+    |> equal(
+         Discount.getHalfOff([|
+           Hotdog,
+           Sandwich(Portabello),
+           Burger({
+             lettuce: true,
+             tomatoes: true,
+             cheese: 1,
+             onions: 1,
+             bacon: 0,
+           }),
+         |]),
+         None,
+       )
+  );
+
+  test("One burger has 1+ of every topping, return Some(15.675)", () =>
+    expect
+    |> equal(
+         Discount.getHalfOff([|
+           Hotdog,
+           Sandwich(Portabello),
+           Burger({
+             lettuce: true,
+             tomatoes: true,
+             cheese: 1,
+             onions: 1,
+             bacon: 1,
+           }),
+         |]),
+         Some(15.675),
+       )
+  );
+};
+// #endregion new-half-off-tests

--- a/docs/burger-discounts/index.md
+++ b/docs/burger-discounts/index.md
@@ -495,7 +495,9 @@ the switch expression entirely.
 
 <b>3.</b> Add a new function `Discount.getHalfOff` that gives you a discount of
 half off the entire meal if there’s at least one burger that has one of every
-topping.
+topping. Add these new tests to `DiscountTests` and make sure they pass:
+
+<<< DiscountTests.re#half-off-tests
 
 ::: details Hint
 
@@ -511,7 +513,11 @@ Use [Js.Array.some](https://melange.re/v3.0.0/api/re/melange/Js/Array/#val-some)
 
 <b>4.</b> Update `Discount.getHalfOff` so that it returns a discount of one half
 off the entire meal if there’s at least one burger that has **at least** one of
-every topping. Also add a couple of tests for this function in `DiscountTests`.
+every topping. While you're at it, update the relevant tests in `DiscountTests`:
+
+<<< DiscountTests.re#new-half-off-tests
+
+Note the use of submodule `HalfOff` to group these two tests together.
 
 ::: details Hint
 
@@ -522,11 +528,6 @@ Use [when](https://reasonml.github.io/docs/en/pattern-matching#when) guard
 ::: details Solution
 
 <<< Discount.re#get-half-off
-
-See
-[DiscountTests.re](https://github.com/melange-re/melange-for-react-devs/blob/main/src/burger-discounts/DiscountTests.re)
-to see how the tests are implemented. Note the use of a submodule to group the
-`Discount.getHalfOff` tests together.
 
 :::
 

--- a/docs/celsius-converter-option/index.md
+++ b/docs/celsius-converter-option/index.md
@@ -1,4 +1,4 @@
-# Celsius Converter using Option
+# Celsius Converter Using Option
 
 After all the changes we made in the last chapter, your `CelsiusConverter.re`
 might look something like this:

--- a/docs/cram-tests/index.md
+++ b/docs/cram-tests/index.md
@@ -381,42 +381,26 @@ Fixed tests:
 <b>3.</b> Recently, some Cafe Emoji customers have gotten into the habit of
 ordering burgers with an absurd number of toppings. You can barely even hold
 these monstrous burgers in your hands, and on the small chance that you manage
-to grab one, it will explode as soon as you bite into it. Madame Jellobutter
-has therefore decided that whenever someone orders a burger with more than 12
-toppings, it will be served in a big bowl. Update the `Item.Burger.toEmoji`
-function so that the following expressions are true:
+to grab one, it will explode as soon as you bite into it. Madame Jellobutter has
+therefore decided that whenever someone orders a burger with more than 12
+toppings, it will be served in a big bowl. Add the following test to
+`BurgerTests`:
 
-```reason
-Item.Burger.toEmoji({
-  lettuce: true,
-  tomatoes: true,
-  onions: 4,
-  cheese: 2,
-  bacon: 5,
-})
-== {js|🍔🥣{🥬,🍅,🧅×4,🧀×2,🥓×5}|js};
+<<< BurgerTests.re#bowl-test
 
-Item.Burger.toEmoji({
-  lettuce: true,
-  tomatoes: true,
-  onions: 4,
-  cheese: 2,
-  bacon: 4,
-})
-== {js|🍔{🥬,🍅,🧅×4,🧀×2,🥓×5}|js};
-```
+Now update `Item.Burger.toEmoji` to make that test pass.
 
-Note that lettuce and tomato each count as 1 topping.
+::: details Hint
+
+Note that `lettuce` and `tomatoes` each count as 1 topping.
+
+:::
 
 ::: details Solution
 
 New version of `Item.Burger.toEmoji`:
 
 <<< Item.re#to-emoji
-
-New test:
-
-<<< BurgerTests.re#bowl-test
 
 :::
 

--- a/docs/cram-tests/index.md
+++ b/docs/cram-tests/index.md
@@ -191,19 +191,19 @@ like this:
 
  See all the files inside the sandbox
    $ npx tree
-+  cram-tests
++  order-confirmation
 +  └── output
 +      └── src
-+          └── cram-tests
++          └── order-confirmation
 +              └── SandwichTests.mjs
 ```
 
 The sandbox directory only contains a single file
-`output/src/cram-tests/SandwichTests.mjs`. Add another explorative cram test:
+`output/src/order-confirmation/SandwichTests.mjs`. Add another explorative cram test:
 
 ```cram
 Show detail of SandwichTests.mjs
-  $ ls -la ./output/src/cram-tests/SandwichTests.mjs
+  $ ls -la ./output/src/order-confirmation/SandwichTests.mjs
 ```
 
 The output should now look like this:
@@ -220,11 +220,11 @@ The output should now look like this:
 +              └── SandwichTests.mjs
 
  Show detail of SandwichTests.mjs
-   $ ls -la ./output/src/cram-tests/SandwichTests.mjs
-+  lrwxr-xr-x  1 fhsu  staff  86 Mar 16 22:09 ./output/src/cram-tests/SandwichTests.mjs -> ../../../../../../../../default/src/cram-tests/output/src/cram-tests/SandwichTests.mjs
+   $ ls -la ./output/src/order-confirmation/SandwichTests.mjs
++  lrwxr-xr-x  1 fhsu  staff  86 Mar 16 22:09 ./output/src/order-confirmation/SandwichTests.mjs -> ../../../../../../../../default/src/order-confirmation/output/src/order-confirmation/SandwichTests.mjs
 ```
 
-From this, you can see that `./output/src/cram-tests/SandwichTests.mjs` is
+From this, you can see that `./output/src/order-confirmation/SandwichTests.mjs` is
 actually a symbolic link which links to the real file inside your build
 directory, specifically this file:
 
@@ -265,7 +265,7 @@ see a failing test, but no errors appear. You have to add `(alias melange)` to
 (cram
  (deps
   (alias melange)
-  ./output/src/cram-tests/SandwichTests.mjs))
+  ./output/src/order-confirmation/SandwichTests.mjs))
 ```
 
 Now the test finally fails. The presence of `(alias melange)` means that all
@@ -437,12 +437,12 @@ and [demo](https://react-book.melange.re/demo/src/cram-tests/) for this chapter.
     see some logging that indicates that build targets were produced, e.g.
 
     ```shell
-    refmt src/cram-tests/Item.re.ml
-    ppx src/cram-tests/Item.re.pp.ml
-    ocamldep src/cram-tests/.output.mobjs/melange__Item.impl.d
-    melc src/cram-tests/.output.mobjs/melange/melange__Item.{cmi,cmj,cmt}
-    melc src/cram-tests/output/src/cram-tests/Item.mjs
-    melc src/cram-tests/.output.mobjs/melange/melange__SandwichTests.{cmi,cmj,cmt}
-    melc src/cram-tests/.output.mobjs/melange/melange__Order.{cmi,cmj,cmt}
-    melc src/cram-tests/.output.mobjs/melange/melange__Index.{cmi,cmj,cmt}
+    refmt src/order-confirmation/Item.re.ml
+    ppx src/order-confirmation/Item.re.pp.ml
+    ocamldep src/order-confirmation/.output.mobjs/melange__Item.impl.d
+    melc src/order-confirmation/.output.mobjs/melange/melange__Item.{cmi,cmj,cmt}
+    melc src/order-confirmation/output/src/order-confirmation/Item.mjs
+    melc src/order-confirmation/.output.mobjs/melange/melange__SandwichTests.{cmi,cmj,cmt}
+    melc src/order-confirmation/.output.mobjs/melange/melange__Order.{cmi,cmj,cmt}
+    melc src/order-confirmation/.output.mobjs/melange/melange__Index.{cmi,cmj,cmt}
     ```

--- a/docs/cram-tests/tests
+++ b/docs/cram-tests/tests
@@ -1,6 +1,6 @@
 # region first-cram
 Sandwich tests
-  $ node ./output/src/cram-tests/SandwichTests.mjs
+  $ node ./output/src/order-confirmation/SandwichTests.mjs
   TAP version 13
   # Subtest: Item.Sandwich.toEmoji
   ok 1 - Item.Sandwich.toEmoji
@@ -30,7 +30,7 @@ Sandwich tests
 
 # region first-burger-cram
 Burger tests
-  $ node ./output/src/cram-tests/BurgerTests.mjs | sed '/duration_ms/d'
+  $ node ./output/src/order-confirmation/BurgerTests.mjs | sed '/duration_ms/d'
   TAP version 13
   # Subtest: A fully-loaded burger
   ok 1 - A fully-loaded burger

--- a/docs/discounts-lists/DiscountTests.re
+++ b/docs/discounts-lists/DiscountTests.re
@@ -9,3 +9,33 @@ test("0 burgers, no discount", () =>
      )
 );
 // #endregion first-test
+
+let burger: Item.Burger.t = {
+  lettuce: false,
+  onions: 0,
+  cheese: 0,
+  tomatoes: false,
+  bacon: 0,
+};
+
+// #region get-free-burgers-test
+test("7 burgers, return Some(46.75)", () =>
+  expect
+  |> equal(
+       Discount.getFreeBurgers([
+         Burger(burger), // 15
+         Hotdog,
+         Burger({...burger, cheese: 5}), // 15.50
+         Sandwich(Unicorn),
+         Burger({...burger, bacon: 4}), // 17.00
+         Burger({...burger, tomatoes: true, cheese: 1}), // 15.15
+         Sandwich(Ham),
+         Burger({...burger, bacon: 2}), // 16.00
+         Burger({...burger, onions: 6}), // 16.20
+         Sandwich(Portabello),
+         Burger({...burger, tomatoes: true}) // 15.05
+       ]),
+       Some(46.75),
+     )
+);
+// #endregion get-free-burgers-test

--- a/docs/discounts-lists/index.md
+++ b/docs/discounts-lists/index.md
@@ -12,7 +12,7 @@ know that tests are only as reliable as the humans that maintain them. By now,
 you've come to realize that The OCaml Way should be to rewrite the function so
 that it **cannot** have side effects.
 
-## Intro to lists
+## Introduction to lists
 
 A [list](https://reasonml.github.io/docs/en/basic-structures#list) is a
 sequential data structure that can often be used in place of an array. In OCaml,
@@ -124,7 +124,7 @@ Inside the "success" branch of the switch expression, we have:
 ```
 
 This pattern will match on lists that have at least two elements. The first
-element is ignored via the wildcard patten `_`. The second element is bound to
+element is ignored via the wildcard pattern `_`. The second element is bound to
 the name `cheaperPrice`, which is encased in `Some` and returned. We use *list
 spread syntax* (`...`) to indicate that the list can have more than the two
 elements we explicitly matched on.
@@ -310,14 +310,14 @@ Because `Stdlib` is automatically opened, normally we can just call
 `Array.of_list`, but we have to use the full name `Stdlib.Array.of_list` because
 our custom `Array` module takes precedence[^2].
 
-To get all your code compiling again, you have to also refactor `Index`. But
-there all you have to do is change the array delimiters (`[||]`) to list
-delimiters (`[]`).
+To get all your code compiling again, you must also fix the code in
+`Index`---but all you have to do in there is change the array delimiters
+(`[||]`) to list delimiters (`[]`).
 
 ## `List.nth_opt`
 
-If we peruse the `List` module a bit, we'll find a function that can make
-`Discount.getFreeBurger` shorter:
+If we peruse the `List` module a bit, we'll find a function that can simplify
+the logic in `Discount.getFreeBurger`:
 [List.nth](https://melange.re/v1.0.0/api/re/melange/Stdlib/List/#val-nth). It
 takes an index `n` that returns the `n`-th element of a list. However, from
 previous experience, we don't want to use unsafe functions like this.
@@ -398,22 +398,23 @@ an order.
 
 - Lists are immutable
 - You can pattern match on a whole list, even if you don't know its length
+- Uses of list spread syntax (`...`):
+  - Create new lists by prepending elements to existing lists
+  - Pattern match on the tail of a list
+- The delimiters for list literals are `[]`
 - The `List` module contains most of the functions you'll need for
   dealing with lists
+- The `ListLabels` module contains the same functions as in `List`, but they
+  have labeled arguments instead of positional arguments
+- The names of equivalent functions in `List` and `Js.Array` might not match
 - The runtime representation of lists:
   - Empty list → `0`
   - Nonempty list → a JavaScript object with the fields `hd` (for head) and `tl`
     (for tail)
-- The delimiters for list literals are `[]`
-- You can use list spread syntax (`...`) to add elements to the front of a list
-  or pattern match on the tail of a list
-  - The names of equivalent functions might not match the names in `Js.Array`
-- Documentation comments show up in editor hover popups and generated
+- Documentation comments:
+  - Show up in editor hover popups and generated
   documentation pages
-  - They can be attached to functions, modules, types, and
-  variables
-- The `ListLabels` module contains the same functions as in `List`, but they
-  have labeled arguments instead of positional arguments
+  - Can be attached to functions, modules, types, and variables
 - The placeholder operator (`_`) can be used to override the position of the
   piped argument when using the pipe last operator
 
@@ -457,6 +458,10 @@ Add a new file `ListSafe.re`:
 `Discount.getFreeBurger` could be refactored to:
 
 <<< Discount.re#get-free-burger-nth{12}
+
+Note that we no longer need the switch expression anymore because
+`ListSafe.nth(1)` will automatically return `None` if there are 0 or 1 items in
+the given list.
 
 :::
 

--- a/docs/discounts-lists/index.md
+++ b/docs/discounts-lists/index.md
@@ -426,6 +426,7 @@ an order.
   `Bool.compare` and `String.compare`.
 - Use
   [List.filter_map](https://melange.re/v2.2.0/api/re/melange/Stdlib/List/#val-filter_map)
+  in place of `List.filter` and `List.map`.
 
 ::: details Solution
 
@@ -460,9 +461,11 @@ Add a new file `ListSafe.re`:
 :::
 
 <b>3.</b> Update the logic of `Discount.getFreeBurger` so that for every pair of
-burgers purchased, one of them is free. You can order the burgers by price
-(descending), and then choose every other burger (starting from the second
-burger) to be free.
+burgers purchased, one of them is free. Order the burgers by price (descending),
+and then choose every other burger (starting from the second burger) to be free.
+Add this new test to `DiscountTests` and make sure it passes:
+
+<<< DiscountTests.re#get-free-burgers-test
 
 ::: details Hint 1
 
@@ -492,16 +495,6 @@ multiple burgers can be free.
 - The switch expression reappears because it's needed to detect the cases when
   the discount can't be applied (when there are less than two burgers in the
   order).
-
-:::
-
-<b>4.</b> Update the tests in `DiscountTests` to work with the new function you
-added in the last exercise, and then add a new test to make sure that the case
-of 4 or more burgers works as expected.
-
-::: details Solution
-
-The updated tests can be found in https://github.com/melange-re/melange-for-react-devs/blob/main/src/discounts-lists/DiscountTests.re
 
 :::
 

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -31,7 +31,7 @@ teaches the language from the ground up and goes much deeper into its features.
 | Counter | Number that can be incremented or decremented | module, Option, `React.string`, pipe last operator, function chaining, switch expression |
 | Numberic Types | Use Melange Playground to explore OCaml’s numeric types | Int, Float, Playground, sharing snippets, comparison operators, arithmetic operators, widgets in Playground |
 | Celsius Converter | Single input that converts from  Celsius to Fahrenheit | `Js.t` object, string concatenation (`++`), exception handling, ternary expression, if-else expression, labeled argument, partial application, `{js\|\|js}` quoted string literal |
-| Celsius Converter using Option | The same component from the last chapter but replacing exception handling with Option | Option, `Option.map`, `when` guard |
+| Celsius Converter Using Option | The same component from the last chapter but replacing exception handling with Option | Option, `Option.map`, `when` guard |
 | Introduction to Dune | A introduction to the Dune build system | `dune-project` file, `dune` file, `melange.emit` stanza, monorepo structure |
 | Order Confirmation | An order confirmation for a restaurant website | variant type, primary type of module (`t`), wildcard (`_`) in switch, `fun` syntax, `Js.Array` functions, `React.array`, type transformation functions |
 | Styling with CSS | Styling the order confirmation using CSS | `mel.raw` extension node, `runtime_deps` field, `glob_files` term, `external`, `mel.module` attribute |

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -40,6 +40,7 @@ teaches the language from the ground up and goes much deeper into its features.
 | Sandwich Tests | Add unit tests for sandwich-related logic | opam switch, `opam switch`, `opam install`, `opam list`, `.opam` file, `melange-fest`, `open` module, `module_systems` field, punning, type inference |
 | Cram Tests | Set up cram tests to run your unit tests | cram tests, `cram` stanza, Dune alias, promotion, test output sanitization, sandbox, `expand_aliases_in_sandbox` stanza |
 | Burger Discounts | Implement burger discount logic using arrays | limits of type inference, type annotation of function arguments, full name (asset path), `Stdlib`, record spread syntax, `ignore`, runtime representations of common data types, properties of arrays, override `Array.get` |
+| Discounts Using Lists | Re-implement burger discount logic using lists | properties of lists, pattern matching on lists, list spread syntax, `List` module, `ListLabels` module, runtime representation of lists, documentation comments, placeholder operator |
 
 ...and much more to come!
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <a href="src/celsius-converter-exception/index.html">Celsius Converter</a>
       </li>
       <li>
-        <a href="src/celsius-converter-option/index.html">Celsius Converter using Option</a>
+        <a href="src/celsius-converter-option/index.html">Celsius Converter Using Option</a>
       </li>
       <li>
         <a href="src/order-confirmation/index.html">Order Confirmation</a>

--- a/src/celsius-converter-option/Index.re
+++ b/src/celsius-converter-option/Index.re
@@ -2,7 +2,7 @@ module App = {
   [@react.component]
   let make = () =>
     <div>
-      <h1> {React.string("Celsius Converter using Option")} </h1>
+      <h1> {React.string("Celsius Converter Using Option")} </h1>
       <CelsiusConverter />
       <h2> {React.string("Using Float.fromString")} </h2>
       <CelsiusConverter_FloatFromString />


### PR DESCRIPTION
Some exercises asked the reader to create or update a function without providing them with explicit tests. This PR fixes them. Also:

- [x] Update chapters & topics table
- [x] Fix some errors in 'Discounts Using Lists' chapter
- [x] Capitalize 'using' in 'Celsius Converter Using Option' chapter  