### PR TITLE
Upgrade melange from 3.0.0-51 to 4.0.0-51

### DIFF
--- a/docs/better-burgers/index.md
+++ b/docs/better-burgers/index.md
@@ -40,7 +40,7 @@ a number of syntactic and practical differences between them:
   types.
 
 The runtime representation of a record is a [plain JavaScript
-object](https://melange.re/v3.0.0/communicate-with-javascript.html#data-types-and-runtime-representation),
+object](https://melange.re/v4.0.0/communicate-with-javascript.html#data-types-and-runtime-representation),
 the same as for a `Js.t` object.
 
 ::: info
@@ -365,7 +365,7 @@ and [demo](https://react-book.melange.re/demo/src/better-burgers/) for this chap
     ```
 
     See this [playground
-    snippet](https://melange.re/v3.0.0/playground/?language=Reason&code=Ly8gVXNlIGEgcmFuZG9tIHZhcmlhYmxlIHNvIGZ1bmN0aW9uIGludm9jYXRpb25zIGFyZW4ndCBvcHRpbWl6ZWQgYXdheQpsZXQgYyA9IFJhbmRvbS5pbnQoMTApOwoKbGV0IGFkZCA9ICh4LCB5LCB6KSA9PiB4ICsgeSArIHo7CkpzLmxvZyhhZGQoMSwgMiwgYykpOwoKLy8gQW4gZXF1aXZhbGVudCBkZWZpbml0aW9uIHRoYXQgZXhwbGljaXRseSByZXR1cm5zIGZ1bmN0aW9uczoKbGV0IGV4cGxpY2l0QWRkID0geCA9PiB5ID0%2BIHogPT4geCArIHkgKyB6OwpKcy5sb2coZXhwbGljaXRBZGQoMSwgMiwgYykpOwovLyBDb25jZXB0dWFsbHksIHRoZXJlIGFyZSBtdWx0aXBsZSBmdW5jdGlvbiBpbnZvY2F0aW9ucy4gQnV0IGluIHRoZSBKUyBvdXRwdXQsCi8vIGl0J3MgYSBzaW5nbGUgZnVuY3Rpb24gY2FsbC4KSnMubG9nKGV4cGxpY2l0QWRkKDEpKDIpKGMpKTs%3D&live=off)
+    snippet](https://melange.re/v4.0.0/playground/?language=Reason&code=Ly8gVXNlIGEgcmFuZG9tIHZhcmlhYmxlIHNvIGZ1bmN0aW9uIGludm9jYXRpb25zIGFyZW4ndCBvcHRpbWl6ZWQgYXdheQpsZXQgYyA9IFJhbmRvbS5pbnQoMTApOwoKbGV0IGFkZCA9ICh4LCB5LCB6KSA9PiB4ICsgeSArIHo7CkpzLmxvZyhhZGQoMSwgMiwgYykpOwoKLy8gQW4gZXF1aXZhbGVudCBkZWZpbml0aW9uIHRoYXQgZXhwbGljaXRseSByZXR1cm5zIGZ1bmN0aW9uczoKbGV0IGV4cGxpY2l0QWRkID0geCA9PiB5ID0%2BIHogPT4geCArIHkgKyB6OwpKcy5sb2coZXhwbGljaXRBZGQoMSwgMiwgYykpOwovLyBDb25jZXB0dWFsbHksIHRoZXJlIGFyZSBtdWx0aXBsZSBmdW5jdGlvbiBpbnZvY2F0aW9ucy4gQnV0IGluIHRoZSBKUyBvdXRwdXQsCi8vIGl0J3MgYSBzaW5nbGUgZnVuY3Rpb24gY2FsbC4KSnMubG9nKGV4cGxpY2l0QWRkKDEpKDIpKGMpKTs%3D&live=off)
     for an extended example and the [official OCaml
     docs](https://ocaml.org/docs/values-and-functions#types-of-functions-of-multiple-parameters)
     for more details.

--- a/docs/better-sandwiches/index.md
+++ b/docs/better-sandwiches/index.md
@@ -134,7 +134,7 @@ put shorter branches before longer branches:
 
 The approach using `Js.Array.join` works, but readability could be improved by
 using a [quoted string literal with the quoted string identifier
-`j`](https://melange.re/v3.0.0/communicate-with-javascript.html#strings):
+`j`](https://melange.re/v4.0.0/communicate-with-javascript.html#strings):
 
 <<< Item.re#to-emoji-j-string-literal{5-13}
 
@@ -149,7 +149,7 @@ multi-line expressions in branches unless you add `{}` around them.
 
 The OCaml standard library also provides a type-safe way to do string
 interpolation in the form of the
-[Printf.sprintf](https://melange.re/v3.0.0/api/re/melange/Stdlib/Printf/index.html#val-sprintf)
+[Printf.sprintf](https://melange.re/v4.0.0/api/re/melange/Stdlib/Printf/index.html#val-sprintf)
 function:
 
 <<< Item.re#to-emoji-sprintf
@@ -159,7 +159,7 @@ literals:
 
 - Since it's just a function, you can pass expressions into it
 - It supports [conversion
-  specifications](https://melange.re/v3.0.0/api/re/melange/Stdlib/Printf/index.html#val-fprintf)
+  specifications](https://melange.re/v4.0.0/api/re/melange/Stdlib/Printf/index.html#val-fprintf)
   like `%s`, `%i`, `%d`, etc which concisely handle basic string conversion
   logic for all primitive data types. This can often make your code shorter and
   easier to understand.
@@ -256,7 +256,7 @@ added is cheaper or more expensive *depending on the day of the week*.
 ::: details Hint 1
 
 Look at the functions in the
-[Js.Date](https://melange.re/v3.0.0/api/re/melange/Js/Date/) module.
+[Js.Date](https://melange.re/v4.0.0/api/re/melange/Js/Date/) module.
 
 :::
 
@@ -307,12 +307,12 @@ let player: Js.t({..}) = {
 
 Use `Printf.sprintf` instead and improve the program as suggested by the
 comments. You can edit the program interactively in [Melange
-Playground](https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGNvbXB1dGUgPSAoYSwgYikgPT4gKGEgKy4gMTAuKSAvLiBiOwoKLy8gUmV3cml0ZSB1c2luZyBQcmludGYuc3ByaW50ZiwgbGltaXQgcmVzdWx0IHRvIDMgZGVjaW1hbCBwbGFjZXMKbGV0IHJlc3VsdCA9IGNvbXB1dGUoNDAuLCA0Ny4pIHw%2BIHN0cmluZ19vZl9mbG9hdDsKSnMubG9nKHtqfHJlc3VsdCB0byAzIGRlY2ltYWwgcGxhY2VzID0gJChyZXN1bHQpfGp9KTsKCi8vIFJld3JpdGUgdXNpbmcgUHJpbnRmLnNwcmludGYKbGV0IHBsYXllcjogSnMudCh7Li59KSA9IHsKICAibmFtZSI6ICJXaWxidXIiLAogICJsZXZlbCI6IDkwMDEyMzQsCiAgImltbW9ydGFsIjogZmFsc2UsCn07CnsKICBsZXQgbmFtZSA9IHBsYXllciMjbmFtZTsKICAvLyBib251czogdXNlIHRoZSBmbGFnIHRoYXQgbWFrZXMgbG9uZyBudW1iZXJzIG1vcmUgcmVhZGFibGUKICBsZXQgbGV2ZWwgPSBwbGF5ZXIjI2xldmVsIHw%2BIHN0cmluZ19vZl9pbnQ7IAogIGxldCBpbW1vcnRhbCA9IHBsYXllciMjaW1tb3J0YWwgfD4gc3RyaW5nX29mX2Jvb2w7CiAgSnMubG9nKHtqfFBsYXllcjogbmFtZT0kKG5hbWUpLCBsZXZlbD0kKGxldmVsKSwgaW1tb3J0YWw9JChpbW1vcnRhbCl8an0pOwp9Owo%3D&live=off).
+Playground](https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGNvbXB1dGUgPSAoYSwgYikgPT4gKGEgKy4gMTAuKSAvLiBiOwoKLy8gUmV3cml0ZSB1c2luZyBQcmludGYuc3ByaW50ZiwgbGltaXQgcmVzdWx0IHRvIDMgZGVjaW1hbCBwbGFjZXMKbGV0IHJlc3VsdCA9IGNvbXB1dGUoNDAuLCA0Ny4pIHw%2BIHN0cmluZ19vZl9mbG9hdDsKSnMubG9nKHtqfHJlc3VsdCB0byAzIGRlY2ltYWwgcGxhY2VzID0gJChyZXN1bHQpfGp9KTsKCi8vIFJld3JpdGUgdXNpbmcgUHJpbnRmLnNwcmludGYKbGV0IHBsYXllcjogSnMudCh7Li59KSA9IHsKICAibmFtZSI6ICJXaWxidXIiLAogICJsZXZlbCI6IDkwMDEyMzQsCiAgImltbW9ydGFsIjogZmFsc2UsCn07CnsKICBsZXQgbmFtZSA9IHBsYXllciMjbmFtZTsKICAvLyBib251czogdXNlIHRoZSBmbGFnIHRoYXQgbWFrZXMgbG9uZyBudW1iZXJzIG1vcmUgcmVhZGFibGUKICBsZXQgbGV2ZWwgPSBwbGF5ZXIjI2xldmVsIHw%2BIHN0cmluZ19vZl9pbnQ7IAogIGxldCBpbW1vcnRhbCA9IHBsYXllciMjaW1tb3J0YWwgfD4gc3RyaW5nX29mX2Jvb2w7CiAgSnMubG9nKHtqfFBsYXllcjogbmFtZT0kKG5hbWUpLCBsZXZlbD0kKGxldmVsKSwgaW1tb3J0YWw9JChpbW1vcnRhbCl8an0pOwp9Owo%3D&live=off).
 
 ::: details Hint
 
 Consult the [conversion specification
-documentation](https://melange.re/v3.0.0/api/re/melange/Stdlib/Printf/index.html#val-fprintf).
+documentation](https://melange.re/v4.0.0/api/re/melange/Stdlib/Printf/index.html#val-fprintf).
 
 :::
 
@@ -320,7 +320,7 @@ documentation](https://melange.re/v3.0.0/api/re/melange/Stdlib/Printf/index.html
 
 After replacing the `{j||j}` quoted string literals with
 `Printf.sprintf` and improving it a bit, you might end up with something [like
-this](https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGNvbXB1dGUgPSAoYSwgYikgPT4gKGEgKy4gMTAuKSAvLiBiOwoKLy8gUmV3cml0ZSB1c2luZyBQcmludGYuc3ByaW50ZiwgbGltaXQgcmVzdWx0IHRvIDMgZGVjaW1hbCBwbGFjZXMKSnMubG9nKAogIFByaW50Zi5zcHJpbnRmKCJyZXN1bHQgdG8gMyBkZWNpbWFsIHBsYWNlcyA9ICUwLjNmIiwgY29tcHV0ZSg0MC4sIDQ3LikpLAopOwoKLy8gUmV3cml0ZSB1c2luZyBQcmludGYuc3ByaW50ZgpsZXQgcGxheWVyOiBKcy50KHsuLn0pID0gewogICJuYW1lIjogIldpbGJ1ciIsCiAgImxldmVsIjogOTAwMTIzNCwKICAiaW1tb3J0YWwiOiBmYWxzZSwKfTsKSnMubG9nKAogIFByaW50Zi5zcHJpbnRmKAogICAgIlBsYXllcjogbmFtZT0lcywgbGV2ZWw9JSNkLCBpbW1vcnRhbD0lQiIsCiAgICBwbGF5ZXIjI25hbWUsCiAgICBwbGF5ZXIjI2xldmVsLAogICAgcGxheWVyIyNpbW1vcnRhbCwKICApLAopOwo%3D&live=off).
+this](https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGNvbXB1dGUgPSAoYSwgYikgPT4gKGEgKy4gMTAuKSAvLiBiOwoKLy8gUmV3cml0ZSB1c2luZyBQcmludGYuc3ByaW50ZiwgbGltaXQgcmVzdWx0IHRvIDMgZGVjaW1hbCBwbGFjZXMKSnMubG9nKAogIFByaW50Zi5zcHJpbnRmKCJyZXN1bHQgdG8gMyBkZWNpbWFsIHBsYWNlcyA9ICUwLjNmIiwgY29tcHV0ZSg0MC4sIDQ3LikpLAopOwoKLy8gUmV3cml0ZSB1c2luZyBQcmludGYuc3ByaW50ZgpsZXQgcGxheWVyOiBKcy50KHsuLn0pID0gewogICJuYW1lIjogIldpbGJ1ciIsCiAgImxldmVsIjogOTAwMTIzNCwKICAiaW1tb3J0YWwiOiBmYWxzZSwKfTsKSnMubG9nKAogIFByaW50Zi5zcHJpbnRmKAogICAgIlBsYXllcjogbmFtZT0lcywgbGV2ZWw9JSNkLCBpbW1vcnRhbD0lQiIsCiAgICBwbGF5ZXIjI25hbWUsCiAgICBwbGF5ZXIjI2xldmVsLAogICAgcGxheWVyIyNpbW1vcnRhbCwKICApLAopOwo%3D&live=off).
 
 :::
 

--- a/docs/burger-discounts/index.md
+++ b/docs/burger-discounts/index.md
@@ -41,17 +41,17 @@ is no second burger, it returns `None`.
 
 The functions used in `Discount.getFreeBurger` are:
 
-- [Js.Array.sortInPlaceWith](https://melange.re/v3.0.0/api/re/melange/Js/Array/index.html#val-sortInPlaceWith)
+- [Js.Array.sortInPlaceWith](https://melange.re/v4.0.0/api/re/melange/Js/Array/index.html#val-sortInPlaceWith)
   takes a callback function `~f` with type signature `('a, 'a) => int` (accept
   two arguments of the same type and return `int`). It's used to sort the items
   by price (highest to lowest).
-- [Stdlib.compare](https://melange.re/v3.0.0/api/re/melange/Stdlib/#val-compare)
+- [Stdlib.compare](https://melange.re/v4.0.0/api/re/melange/Stdlib/#val-compare)
   has type signature `('a, 'a) => int`. It's a polymorphic function capable of
   comparing many types, including `bool`, `int`, `string`, etc. Note that you
   can always just write `compare` instead of `Stdlib.compare`, because the
   [`Stdlib` module is always opened by
-  default](https://melange.re/v3.0.0/api/re/melange/Stdlib/).
-- [Js.Array.filter](https://melange.re/v3.0.0/api/re/melange/Js/Array/#val-filter)
+  default](https://melange.re/v4.0.0/api/re/melange/Stdlib/).
+- [Js.Array.filter](https://melange.re/v4.0.0/api/re/melange/Js/Array/#val-filter)
   takes a callback function `~f` with type signature `'a => bool`. It's used to
   make sure all items in the `burgers` array are all burgers.
 
@@ -216,7 +216,7 @@ return value is `()` (the [unit
 value](https://reasonml.github.io/docs/en/overview#unit)). However, inside this
 test, we are calling `Discount.getFreeBurger` to test its side effects, so the
 return value isn't needed; as such, we can explicitly discard it by using
-[Stdlib.ignore](https://melange.re/v3.0.0/api/re/melange/Stdlib/#val-ignore)[^2]:
+[Stdlib.ignore](https://melange.re/v4.0.0/api/re/melange/Stdlib/#val-ignore)[^2]:
 
 ```reason
 Discount.getFreeBurger(items) |> ignore;
@@ -278,7 +278,7 @@ contains all the items, are turned into JS arrays.
 Variant constructors in the runtime don't always have the `TAG` field. That
 field only appears when there's more than one variant constructor with an
 argument. See [Data types and runtime
-representation](https://melange.re/v3.0.0/communicate-with-javascript.html#data-types-and-runtime-representation)
+representation](https://melange.re/v4.0.0/communicate-with-javascript.html#data-types-and-runtime-representation)
 for more details.
 
 :::
@@ -363,8 +363,8 @@ In OCaml, the array access operator `[]` is just a function call. That is,
 `burger[0]` is completely equivalent to `Array.get(burger, 0)`.
 
 Since the [`Stdlib` module is opened by
-default](https://melange.re/v3.0.0/api/re/melange/Stdlib/), the
-[Stdlib.Array.get](https://melange.re/v3.0.0/api/re/melange/Stdlib/Array/#val-get)
+default](https://melange.re/v4.0.0/api/re/melange/Stdlib/), the
+[Stdlib.Array.get](https://melange.re/v4.0.0/api/re/melange/Stdlib/Array/#val-get)
 function is used for `Array.get`, but it's possible to override this by defining
 our own `Array` module. Add a new file `src/order-confirmation/Array.re`:
 
@@ -416,7 +416,7 @@ variable, e.g.
 <<< Discount.re#return-variant-at-end
 
 See [full example on Melange
-Playground](https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGNpcGhlckdyZWV0aW5nID0gbmFtZSA9PiB7CiAgc3dpdGNoIChTdHJpbmcudHJpbShuYW1lKSkgewogIHwgIiIgPT4gTm9uZQogIHwgbmFtZSA9PgogICAgbGV0IHJlc3VsdCA9CiAgICAgIG5hbWUKICAgICAgfD4gU3RyaW5nLnNwbGl0X29uX2NoYXIoJyAnKQogICAgICB8PiBMaXN0Lm1hcChTdHJpbmcubWFwKGMgPT4gYyB8PiBDaGFyLmNvZGUgfD4gKCspKDEpIHw%2BIENoYXIuY2hyKSkKICAgICAgfD4gU3RyaW5nLmNvbmNhdCgiICIpCiAgICAgIHw%2BIFN0cmluZy5jYXQoIkhlbGxvLCAiKTsKCiAgICBTb21lKHJlc3VsdCk7CiAgfTsKfTsKCkpzLmxvZyhjaXBoZXJHcmVldGluZygiIikpOwpKcy5sb2coY2lwaGVyR3JlZXRpbmcoIlhhdmllciBMZXJveSIpKTsK&live=off).
+Playground](https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGNpcGhlckdyZWV0aW5nID0gbmFtZSA9PiB7CiAgc3dpdGNoIChTdHJpbmcudHJpbShuYW1lKSkgewogIHwgIiIgPT4gTm9uZQogIHwgbmFtZSA9PgogICAgbGV0IHJlc3VsdCA9CiAgICAgIG5hbWUKICAgICAgfD4gU3RyaW5nLnNwbGl0X29uX2NoYXIoJyAnKQogICAgICB8PiBMaXN0Lm1hcChTdHJpbmcubWFwKGMgPT4gYyB8PiBDaGFyLmNvZGUgfD4gKCspKDEpIHw%2BIENoYXIuY2hyKSkKICAgICAgfD4gU3RyaW5nLmNvbmNhdCgiICIpCiAgICAgIHw%2BIFN0cmluZy5jYXQoIkhlbGxvLCAiKTsKCiAgICBTb21lKHJlc3VsdCk7CiAgfTsKfTsKCkpzLmxvZyhjaXBoZXJHcmVldGluZygiIikpOwpKcy5sb2coY2lwaGVyR3JlZXRpbmcoIlhhdmllciBMZXJveSIpKTsK&live=off).
 
 ---
 
@@ -469,7 +469,7 @@ Also refactor the "failure" pattern match so there's no wildcard.
 
 ::: details Hint
 
-Use [Js.Array.map](https://melange.re/v3.0.0/api/re/melange/Js/Array/#val-map)
+Use [Js.Array.map](https://melange.re/v4.0.0/api/re/melange/Js/Array/#val-map)
 
 :::
 
@@ -501,7 +501,7 @@ topping. Add these new tests to `DiscountTests` and make sure they pass:
 
 ::: details Hint
 
-Use [Js.Array.some](https://melange.re/v3.0.0/api/re/melange/Js/Array/#val-some)
+Use [Js.Array.some](https://melange.re/v4.0.0/api/re/melange/Js/Array/#val-some)
 
 :::
 
@@ -554,6 +554,6 @@ and [demo](https://react-book.melange.re/demo/src/burger-discounts/) for this ch
     approach.
 
 [^3]: Technically [`option` is a
-    variant](https://melange.re/v3.0.0/api/re/melange/Stdlib/Option/#type-t),
+    variant](https://melange.re/v4.0.0/api/re/melange/Stdlib/Option/#type-t),
     but Melange treats them as a special case---`option` values are never
     represented as JS objects in the runtime.

--- a/docs/celsius-converter-exception/index.md
+++ b/docs/celsius-converter-exception/index.md
@@ -101,13 +101,13 @@ haven't quite gotten used to OCaml syntax yet.
 If we enter a value with a lot of decimals in it, e.g. `21.1223456`, we'll
 get a Fahrenheit value with a lot of decimals in it as well. We can limit the
 number of decimals in the converted value using
-[Js.Float.toFixed](https://melange.re/v3.0.0/api/re/melange/Js/Float/index.html#val-toFixed):
+[Js.Float.toFixed](https://melange.re/v4.0.0/api/re/melange/Js/Float/index.html#val-toFixed):
 
 <<< Snippets.re#fixed-precision{8,11}
 
 `Js.Float.toFixed` is a function that has one positional argument
 and one [labeled
-argument](https://melange.re/v3.0.0/communicate-with-javascript.html#labeled-arguments).
+argument](https://melange.re/v4.0.0/communicate-with-javascript.html#labeled-arguments).
 In this case, the labeled argument is named `digits` and it's receiving a value
 of `2`. It's not possible to pass in the value of a labeled argument without
 using the `~label=value` syntax. We'll see more of labeled arguments in the
@@ -146,7 +146,7 @@ Try changing `{js|°C = |js}` to `"°C = "`.
 
 Changing it to `"°C = "` will result in a bit of gibberish being rendered  in
 the browser: `Â°C`. We can't rely on normal OCaml strings to [deal with Unicode
-correctly](https://melange.re/v3.0.0/communicate-with-javascript.html#strings),
+correctly](https://melange.re/v4.0.0/communicate-with-javascript.html#strings),
 so any string that contains non-ASCII text must be delimited using `{js||js}`
 and not `""`. This kind of string constant is called a `{js||js}` *quoted string
 literal* and it is specific to Melange, meaning it is not available in native
@@ -229,11 +229,11 @@ Js.log(addFive(10));
 ```
 
 What do you think it outputs? Run it in [Melange
-Playground](https://melange.re/v3.0.0/playground) to confirm your hypothesis.
+Playground](https://melange.re/v4.0.0/playground) to confirm your hypothesis.
 
 ::: details Solution
 
-Playground: [Define an addFive function using partial application](https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGFkZEZpdmUgPSAoKykoNSk7CkpzLmxvZyhhZGRGaXZlKDIpKTsKSnMubG9nKGFkZEZpdmUoNykpOwpKcy5sb2coYWRkRml2ZSgxMCkpOw%3D%3D&live=off)
+Playground: [Define an addFive function using partial application](https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGFkZEZpdmUgPSAoKykoNSk7CkpzLmxvZyhhZGRGaXZlKDIpKTsKSnMubG9nKGFkZEZpdmUoNykpOwpKcy5sb2coYWRkRml2ZSgxMCkpOw%3D%3D&live=off)
 
 :::
 
@@ -244,7 +244,7 @@ that result to binary.
 ::: details Hint
 
 Use the
-[Js.Int.toString](https://melange.re/v3.0.0/api/re/melange/Js/Int/#val-toString)
+[Js.Int.toString](https://melange.re/v4.0.0/api/re/melange/Js/Int/#val-toString)
 function.
 
 :::
@@ -252,7 +252,7 @@ function.
 ::: details Solution
 
 Playground: [Define a function that subtracts from 10 and converts to
-binary](https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGNvb2xGdW5jdGlvbiA9IHggPT4geCB8PiAoKC0pKDEwKSkgfD4gSnMuSW50LnRvU3RyaW5nKH5yYWRpeD0yKTsKSnMubG9nKGNvb2xGdW5jdGlvbigxKSk7CkpzLmxvZyhjb29sRnVuY3Rpb24oNSkpOw%3D%3D&live=off)
+binary](https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGNvb2xGdW5jdGlvbiA9IHggPT4geCB8PiAoKC0pKDEwKSkgfD4gSnMuSW50LnRvU3RyaW5nKH5yYWRpeD0yKTsKSnMubG9nKGNvb2xGdW5jdGlvbigxKSk7CkpzLmxvZyhjb29sRnVuY3Rpb24oNSkpOw%3D%3D&live=off)
 
 :::
 
@@ -266,5 +266,5 @@ and [demo](https://react-book.melange.re/demo/src/celsius-converter-exception/) 
 
 [^1]:
     See [Using Js.t
-    objects](https://melange.re/v3.0.0/communicate-with-javascript.html#using-js-t-objects) for more
+    objects](https://melange.re/v4.0.0/communicate-with-javascript.html#using-js-t-objects) for more
     details.

--- a/docs/celsius-converter-option/index.md
+++ b/docs/celsius-converter-option/index.md
@@ -104,7 +104,7 @@ let map = (func, option) =>
 
 You may be interested in browsing the many other helper functions related to
 `option` in the standard library's [Option
-module](https://melange.re/v3.0.0/api/re/melange/Stdlib/Option/).
+module](https://melange.re/v4.0.0/api/re/melange/Stdlib/Option/).
 
 At this point, your switch expression might look like this:
 
@@ -132,7 +132,7 @@ nesting of conditionals to a minimum and making your code more readable.
 Hooray! Our Celsius converter is finally complete. Later, we'll see how to
 [create a component that can convert back and forth between Celsius and
 Fahrenheit](/todo). But first, we'll explore [Dune, the build
-system](https://melange.re/v3.0.0/build-system.html) used by Melange.
+system](https://melange.re/v4.0.0/build-system.html) used by Melange.
 
 ## Overview
 
@@ -176,14 +176,14 @@ Add another `Some(fahrenheit)` branch with a `when` guard:
 :::
 
 <b>3.</b> Use
-[Js.Float.fromString](https://melange.re/v3.0.0/api/re/melange/Js/Float/#val-fromString)
+[Js.Float.fromString](https://melange.re/v4.0.0/api/re/melange/Js/Float/#val-fromString)
 instead of `float_of_string_opt` to parse a string to float. Note that
 `Js.Float.fromString` does not return `None` if it fails to parse a string to a
 valid float.
 
 ::: details Hint
 
-Use [Js.Float.isNaN](https://melange.re/v3.0.0/api/re/melange/Js/Float/#val-isNaN).
+Use [Js.Float.isNaN](https://melange.re/v4.0.0/api/re/melange/Js/Float/#val-isNaN).
 
 :::
 

--- a/docs/counter/index.md
+++ b/docs/counter/index.md
@@ -43,7 +43,7 @@ comes from the name of the module.
 The `make` function has the type `unit => React.element`, meaning it takes `()`
 as the only argument and returns an object of type `React.element`. You'll need
 to decorate `make` with the
-[attribute](https://melange.re/v3.0.0/communicate-with-javascript.html#attributes)
+[attribute](https://melange.re/v4.0.0/communicate-with-javascript.html#attributes)
 `@react.component`. We'll go into the details [later](/todo), but for now
 let's just say that `@react.component` is there to reduce boilerplate and make
 our code more readable and easier to maintain.
@@ -102,7 +102,7 @@ read from left to right:
 {counter |> Int.to_string |> React.string}
 ```
 
-This uses the [pipe last operator](https://melange.re/v3.0.0/communicate-with-javascript.html#pipe-last),
+This uses the [pipe last operator](https://melange.re/v4.0.0/communicate-with-javascript.html#pipe-last),
 which is useful for chaining function calls.
 
 ## Basic styling

--- a/docs/cram-tests/index.md
+++ b/docs/cram-tests/index.md
@@ -4,7 +4,7 @@ Now that you have a set of unit tests for sandwich-related logic, you realize it
 would be nice to have some unit tests for burger-related logic as well. But
 adding a new command to your `test` npm script doesn't feel like The OCaml Way,
 so you hop on the [Reason Discord
-chatroom](https://melange.re/v3.0.0/community.html#community) to ask for advice.
+chatroom](https://melange.re/v4.0.0/community.html#community) to ask for advice.
 MonadicFanatic1984 once again comes to your aid and points you toward *cram
 tests*.
 

--- a/docs/discounts-lists/index.md
+++ b/docs/discounts-lists/index.md
@@ -476,7 +476,7 @@ Add this new test to `DiscountTests` and make sure it passes:
 
 Use
 [List.filteri](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-filteri)
-and [mod operator](https://ocaml.org/manual/5.1/expr.html#ss:expr-operators).
+and [mod operator](https://v2.ocaml.org/manual/expr.html#ss:expr-operators).
 
 :::
 

--- a/docs/discounts-lists/index.md
+++ b/docs/discounts-lists/index.md
@@ -21,9 +21,9 @@ lists](https://en.wikipedia.org/wiki/Linked_list#Singly_linked_list). The main
 limitation is that they don't allow constant-time access to any element except
 the first one (also known as the *head* of a list). Most operations on lists go
 through the [Stdlib.List
-module](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/), which has many
+module](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/), which has many
 functions that are equivalent to the ones you've already used in
-[Js.Array](https://melange.re/v3.0.0/api/re/melange/Js/Array/).
+[Js.Array](https://melange.re/v4.0.0/api/re/melange/Js/Array/).
 
 ::: tip
 
@@ -86,17 +86,17 @@ generators like [odoc](https://ocaml.github.io/odoc/).
 ## `List` functions
 
 We replaced these functions with their counterparts in the [List
-module](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/):
+module](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/):
 
 - `Js.Array.filter` →
-  [List.filter](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-filter).
+  [List.filter](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-filter).
   Note that `List.filter` doesn’t accept the labeled argument `~f`, because the
   functions inside `List` don't use labeled arguments.
 - `Js.Array.map` →
-  [List.map](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-map).
+  [List.map](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-map).
   `List.map` also doesn’t accept the labeled argument `~f`.
 - `Js.Array.sortInPlaceWith` →
-  [List.sort](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-sort).
+  [List.sort](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-sort).
   `List.sort` returns a brand new list, because, unlike
 `Js.Array.sortInPlaceWith`, it doesn’t modify its argument (and it can’t, since
   lists are immutable).
@@ -185,7 +185,7 @@ switch (["one", "two", "three"]) {
 ## Runtime representation of lists
 
 Run this snippet in [Melange
-Playground](https://melange.re/v3.0.0/playground/?language=Reason&code=SnMubG9nMyhBcnJheS5vZl9saXN0KFtdKSwgIi0%2BIiwgW10pOwpKcy5sb2czKEFycmF5Lm9mX2xpc3QoWzQyXSksICItPiIsIFs0Ml0pOwpKcy5sb2czKEFycmF5Lm9mX2xpc3QoWzQsIDUsIDZdKSwgIi0%2BIiwgWzQsIDUsIDZdKTsK&live=off):
+Playground](https://melange.re/v4.0.0/playground/?language=Reason&code=SnMubG9nMyhBcnJheS5vZl9saXN0KFtdKSwgIi0%2BIiwgW10pOwpKcy5sb2czKEFycmF5Lm9mX2xpc3QoWzQyXSksICItPiIsIFs0Ml0pOwpKcy5sb2czKEFycmF5Lm9mX2xpc3QoWzQsIDUsIDZdKSwgIi0%2BIiwgWzQsIDUsIDZdKTsK&live=off):
 
 ```reason
 Js.log3(Array.of_list([]), "->", []);
@@ -252,11 +252,11 @@ Let's now refactor `Discount.getHalfOff` to use lists:
 Again, we swap out array functions for list functions:
 
 - `Js.Array.some` →
-  [List.exists](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-exists).
+  [List.exists](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-exists).
   Note that this is one of several functions in `List` that have different names
   than their counterparts in `Js.Array`.
 - `Js.Array.reduce` →
-  [List.fold_left](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-fold_left).
+  [List.fold_left](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-fold_left).
   Despite its name, `fold_left`[^1] has the same meaning as `reduce`.
 
 Remember to fix the `Discount.getHalfOff` tests inside `DiscountTests`, and then
@@ -294,7 +294,7 @@ Again, we’re mostly just replacing array functions with list functions:
 
 - `Js.Array.reduce` → `ListLabels.fold_left`
 - `Js.Array.mapi` →
-  [List.mapi](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-mapi).
+  [List.mapi](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-mapi).
   Note that the order of the callback arguments has been reversed. For
   `Js.Array.mapi` it’s `(item, index)`, but for `List.mapi` it’s `(index,
   item)`.
@@ -475,7 +475,7 @@ Add this new test to `DiscountTests` and make sure it passes:
 ::: details Hint 1
 
 Use
-[List.filteri](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-filteri)
+[List.filteri](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-filteri)
 and [mod operator](https://v2.ocaml.org/manual/expr.html#ss:expr-operators).
 
 :::
@@ -483,8 +483,8 @@ and [mod operator](https://v2.ocaml.org/manual/expr.html#ss:expr-operators).
 ::: details Hint 2
 
 Use
-[ListLabels.fold_left](https://melange.re/v3.0.0/api/re/melange/Stdlib/ListLabels/#val-fold_left)
-or [List.fold_left](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-fold_left)
+[ListLabels.fold_left](https://melange.re/v4.0.0/api/re/melange/Stdlib/ListLabels/#val-fold_left)
+or [List.fold_left](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-fold_left)
 
 :::
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -9,7 +9,7 @@ Linux](https://learn.microsoft.com/en-us/windows/wsl/)
   - [Node.js](https://nodejs.org/)
   - [git](https://git-scm.com/)
   - A code editor such as [Visual Studio Code](https://code.visualstudio.com/)
-    - There are also [many other editors](https://melange.re/v3.0.0/getting-started.html#editor-integration)
+    - There are also [many other editors](https://melange.re/v4.0.0/getting-started.html#editor-integration)
       which can support OCaml
 
 ## Opam

--- a/docs/intro-to-dune/index.md
+++ b/docs/intro-to-dune/index.md
@@ -5,7 +5,7 @@ your project. Since these components don't have much in common with each other,
 it makes sense to put them in separate, independent single-page apps. To do
 that, we'll use [Dune](https://dune.build/), a build system designed for OCaml
 projects, with many [useful
-features](https://melange.re/v3.0.0/build-system.html#features). For our purposes,
+features](https://melange.re/v4.0.0/build-system.html#features). For our purposes,
 the feature of primary interest is its [built-in support for
 Melange](https://dune.readthedocs.io/en/stable/melange.html).
 
@@ -73,7 +73,7 @@ the root directory of your project:
  (libraries reason-react)
  ; The `preprocess` field lists preprocessors which transform code before it is
  ; compiled. melange.ppx allows to use Melange attributes [@mel. ...]
- ; (https://melange.re/v3.0.0/communicate-with-javascript.html#attributes)
+ ; (https://melange.re/v4.0.0/communicate-with-javascript.html#attributes)
  ; reason-react-ppx allows to use JSX for ReasonReact components by using the
  ; [@JSX] attributes from Reason: https://reasonml.github.io/docs/en/jsx
  (preprocess
@@ -127,7 +127,7 @@ the `index.html` file in the root directory:
 
 For more details about where JavaScript output files end up in the build
 directory, see [JavaScript artifacts
-layout](https://melange.re/v3.0.0/build-system.html#javascript-artifacts-layout).
+layout](https://melange.re/v4.0.0/build-system.html#javascript-artifacts-layout).
 
 ::: tip
 
@@ -257,7 +257,7 @@ every single project.
 ::: info
 
 Melange documentation's [guidelines for
-melange.emit](https://melange.re/v3.0.0/build-system.html#guidelines-for-melange-emit)
+melange.emit](https://melange.re/v4.0.0/build-system.html#guidelines-for-melange-emit)
 recommends you put the `melange.emit` stanza in the `dune` file in the project's
 root directory. We are no longer doing that going forward, but this is still
 great advice if your repo only contains a single app!

--- a/docs/numeric-types/index.md
+++ b/docs/numeric-types/index.md
@@ -23,7 +23,7 @@ Js.log(bar);
 
 ## Melange Playground
 
-[Melange Playground](https://melange.re/v3.0.0/playground/) is an interactive
+[Melange Playground](https://melange.re/v4.0.0/playground/) is an interactive
 environment for running OCaml code and seeing its output. Paste this into the
 source code editor on the left side:
 
@@ -96,9 +96,9 @@ your friends! As you type in the source editor, it will store your code in the
 snippet we started with:
 
 <a
-href="https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGZvbyA9IDQyOwpsZXQgYmFyID0gNDIuMTsKSnMubG9nKGZvbyk7CkpzLmxvZyhiYXIpOw%3D%3D&live=off"
+href="https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGZvbyA9IDQyOwpsZXQgYmFyID0gNDIuMTsKSnMubG9nKGZvbyk7CkpzLmxvZyhiYXIpOw%3D%3D&live=off"
 target="_blank" rel="noreferrer
-noopener">https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGZvbyA9IDQyOwpsZXQgYmFyID0gNDIuMTsKSnMubG9nKGZvbyk7CkpzLmxvZyhiYXIpOw%3D%3D&live=off</a>
+noopener">https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGZvbyA9IDQyOwpsZXQgYmFyID0gNDIuMTsKSnMubG9nKGZvbyk7CkpzLmxvZyhiYXIpOw%3D%3D&live=off</a>
 
 ## Comparison operators
 
@@ -175,7 +175,7 @@ Js.log(Js.typeof(foo)); // prints "number"
 Js.log(Js.typeof(bar)); // prints "number"
 ```
 
-Refer to the [Melange docs](https://melange.re/v3.0.0/communicate-with-javascript.html#data-types-and-runtime-representation)
+Refer to the [Melange docs](https://melange.re/v4.0.0/communicate-with-javascript.html#data-types-and-runtime-representation)
 for a complete rundown of how OCaml types get translated to JavaScript types.
 
 ## Widgets in the Playground
@@ -200,7 +200,7 @@ And then update the JSX in our `make` function to use the style objects in
 <<< Snippets.re#render-with-styles{1-2,5,8}
 
 
-Here's the [playground link](https://melange.re/v3.0.0/playground/?language=Reason&code=bW9kdWxlIFN0eWxlcyA9IHsKICBsZXQgbWFrZSA9IFJlYWN0RE9NLlN0eWxlLm1ha2U7CgogIGxldCByb290ID0KICAgIG1ha2UoCiAgICAgIH5mb250U2l6ZT0iMmVtIiwKICAgICAgfnBhZGRpbmc9IjFlbSIsCiAgICAgIH5kaXNwbGF5PSJmbGV4IiwKICAgICAgfmdyaWRHYXA9IjFlbSIsCiAgICAgIH5hbGlnbkl0ZW1zPSJjZW50ZXIiLAogICAgICAoKSwKICAgICk7CgogIGxldCBidXR0b24gPQogICAgbWFrZSgKICAgICAgfmZvbnRTaXplPSIxZW0iLAogICAgICB%2BYm9yZGVyPSIxcHggc29saWQgd2hpdGUiLAogICAgICB%2BYm9yZGVyUmFkaXVzPSIwLjVlbSIsCiAgICAgIH5wYWRkaW5nPSIwLjVlbSIsCiAgICAgICgpLAogICAgKTsKCiAgbGV0IG51bWJlciA9IG1ha2Uofm1pbldpZHRoPSIyZW0iLCB%2BdGV4dEFsaWduPSJjZW50ZXIiLCAoKSk7Cn07Cgptb2R1bGUgQ291bnRlciA9IHsKICBbQHJlYWN0LmNvbXBvbmVudF0KICBsZXQgbWFrZSA9ICgpID0%2BIHsKICAgIGxldCAoY291bnRlciwgc2V0Q291bnRlcikgPSBSZWFjdC51c2VTdGF0ZSgoKSA9PiAwKTsKCiAgICA8ZGl2IHN0eWxlPVN0eWxlcy5yb290PgogICAgICA8YnV0dG9uIHN0eWxlPVN0eWxlcy5idXR0b24gb25DbGljaz17X2V2dCA9PiBzZXRDb3VudGVyKHYgPT4gdiAtIDEpfT4KICAgICAgICB7UmVhY3Quc3RyaW5nKCItIil9CiAgICAgIDwvYnV0dG9uPgogICAgICA8c3BhbiBzdHlsZT1TdHlsZXMubnVtYmVyPgogICAgICAgIHtjb3VudGVyIHw%2BIEludC50b19zdHJpbmcgfD4gUmVhY3Quc3RyaW5nfQogICAgICA8L3NwYW4%2BCiAgICAgIDxidXR0b24gc3R5bGU9U3R5bGVzLmJ1dHRvbiBvbkNsaWNrPXtfZXZ0ID0%2BIHNldENvdW50ZXIodiA9PiB2ICsgMSl9PgogICAgICAgIHtSZWFjdC5zdHJpbmcoIisiKX0KICAgICAgPC9idXR0b24%2BCiAgICA8L2Rpdj47CiAgfTsKfTsKCnN3aXRjaCAoUmVhY3RET00ucXVlcnlTZWxlY3RvcigiI3ByZXZpZXciKSkgewp8IE5vbmUgPT4gSnMubG9nKCJGYWlsZWQgdG8gc3RhcnQgUmVhY3Q6IGNvdWxkbid0IGZpbmQgdGhlICNwcmV2aWV3IGVsZW1lbnQiKQp8IFNvbWUocm9vdCkgPT4KICBsZXQgcm9vdCA9IFJlYWN0RE9NLkNsaWVudC5jcmVhdGVSb290KHJvb3QpOwogIFJlYWN0RE9NLkNsaWVudC5yZW5kZXIocm9vdCwgPENvdW50ZXIgLz4pOwp9Owo%3D&live=on) for the fully-styled Counter component.
+Here's the [playground link](https://melange.re/v4.0.0/playground/?language=Reason&code=bW9kdWxlIFN0eWxlcyA9IHsKICBsZXQgbWFrZSA9IFJlYWN0RE9NLlN0eWxlLm1ha2U7CgogIGxldCByb290ID0KICAgIG1ha2UoCiAgICAgIH5mb250U2l6ZT0iMmVtIiwKICAgICAgfnBhZGRpbmc9IjFlbSIsCiAgICAgIH5kaXNwbGF5PSJmbGV4IiwKICAgICAgfmdyaWRHYXA9IjFlbSIsCiAgICAgIH5hbGlnbkl0ZW1zPSJjZW50ZXIiLAogICAgICAoKSwKICAgICk7CgogIGxldCBidXR0b24gPQogICAgbWFrZSgKICAgICAgfmZvbnRTaXplPSIxZW0iLAogICAgICB%2BYm9yZGVyPSIxcHggc29saWQgd2hpdGUiLAogICAgICB%2BYm9yZGVyUmFkaXVzPSIwLjVlbSIsCiAgICAgIH5wYWRkaW5nPSIwLjVlbSIsCiAgICAgICgpLAogICAgKTsKCiAgbGV0IG51bWJlciA9IG1ha2Uofm1pbldpZHRoPSIyZW0iLCB%2BdGV4dEFsaWduPSJjZW50ZXIiLCAoKSk7Cn07Cgptb2R1bGUgQ291bnRlciA9IHsKICBbQHJlYWN0LmNvbXBvbmVudF0KICBsZXQgbWFrZSA9ICgpID0%2BIHsKICAgIGxldCAoY291bnRlciwgc2V0Q291bnRlcikgPSBSZWFjdC51c2VTdGF0ZSgoKSA9PiAwKTsKCiAgICA8ZGl2IHN0eWxlPVN0eWxlcy5yb290PgogICAgICA8YnV0dG9uIHN0eWxlPVN0eWxlcy5idXR0b24gb25DbGljaz17X2V2dCA9PiBzZXRDb3VudGVyKHYgPT4gdiAtIDEpfT4KICAgICAgICB7UmVhY3Quc3RyaW5nKCItIil9CiAgICAgIDwvYnV0dG9uPgogICAgICA8c3BhbiBzdHlsZT1TdHlsZXMubnVtYmVyPgogICAgICAgIHtjb3VudGVyIHw%2BIEludC50b19zdHJpbmcgfD4gUmVhY3Quc3RyaW5nfQogICAgICA8L3NwYW4%2BCiAgICAgIDxidXR0b24gc3R5bGU9U3R5bGVzLmJ1dHRvbiBvbkNsaWNrPXtfZXZ0ID0%2BIHNldENvdW50ZXIodiA9PiB2ICsgMSl9PgogICAgICAgIHtSZWFjdC5zdHJpbmcoIisiKX0KICAgICAgPC9idXR0b24%2BCiAgICA8L2Rpdj47CiAgfTsKfTsKCnN3aXRjaCAoUmVhY3RET00ucXVlcnlTZWxlY3RvcigiI3ByZXZpZXciKSkgewp8IE5vbmUgPT4gSnMubG9nKCJGYWlsZWQgdG8gc3RhcnQgUmVhY3Q6IGNvdWxkbid0IGZpbmQgdGhlICNwcmV2aWV3IGVsZW1lbnQiKQp8IFNvbWUocm9vdCkgPT4KICBsZXQgcm9vdCA9IFJlYWN0RE9NLkNsaWVudC5jcmVhdGVSb290KHJvb3QpOwogIFJlYWN0RE9NLkNsaWVudC5yZW5kZXIocm9vdCwgPENvdW50ZXIgLz4pOwp9Owo%3D&live=on) for the fully-styled Counter component.
 
 -----
 
@@ -258,7 +258,7 @@ low]`, where `high` is signed, `low` is unsigned.
 ::: details Hint
 
 Take a look at the standard library's [Int64
-module](https://melange.re/v3.0.0/api/re/melange/Stdlib/Int64/index.html).
+module](https://melange.re/v4.0.0/api/re/melange/Stdlib/Int64/index.html).
 
 :::
 

--- a/docs/order-confirmation/index.md
+++ b/docs/order-confirmation/index.md
@@ -136,12 +136,12 @@ There's a lot going on here:
 - The `Order.make` function has a single labeled argument, `~items`, of type
   `Order.t`. This means the `Order` component has a single prop named `items`.
 - We sum up the prices of all items using
-  [Js.Array.reduce](https://melange.re/v3.0.0/api/re/melange/Js/Array/index.html#val-reduce),
+  [Js.Array.reduce](https://melange.re/v4.0.0/api/re/melange/Js/Array/index.html#val-reduce),
  which is the Melange binding to JavaScript's [Array.reduce
   method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce).
   Note that `Js.Array.reduce` requires the initial value to be passed in.
 - For each order, we render an `Item` component via
-  [Js.Array.map](https://melange.re/v3.0.0/api/re/melange/Js/Array/index.html#val-map),
+  [Js.Array.map](https://melange.re/v4.0.0/api/re/melange/Js/Array/index.html#val-map),
   which is the Melange binding to the [Array.map
   method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
 - There's a call to `React.array`, which we'll address in a little bit.
@@ -163,7 +163,7 @@ Warning: Each child in a list should have a unique "key" prop.
 ```
 
 Oops, we forgot the set the `key` prop! One way to fix this is to use
-[Js.Array.mapi](https://melange.re/v3.0.0/api/re/melange/Js/Array/index.html#val-mapi)
+[Js.Array.mapi](https://melange.re/v4.0.0/api/re/melange/Js/Array/index.html#val-mapi)
 instead[^4] so we can set `key` based on the index of the element:
 
 <<< Order.re#mapi
@@ -178,7 +178,7 @@ If you hover over it, you'll see that it has the type signature
 
 When a JavaScript function has optional arguments, it's common to create
 [multiple OCaml functions that bind to
-it](https://melange.re/v3.0.0/communicate-with-javascript.html#approach-1-multiple-external-functions).
+it](https://melange.re/v4.0.0/communicate-with-javascript.html#approach-1-multiple-external-functions).
 We'll discuss this in more detail [later](/todo).
 
 ## Type transformations in JSX
@@ -214,7 +214,7 @@ To better see what types are at play, it might make sense to refactor
 `React.array` is a strict type transformation that doesn't actually change the
 underlying JavaScript object. For example, try running the [following code in
 the
-playground](https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGVsZW1BcnJheTogYXJyYXkoUmVhY3QuZWxlbWVudCkgPQogICAgW3wiYSIsICJiIiwgImMifF0gfD4gSnMuQXJyYXkubWFwKH5mPXggPT4gUmVhY3Quc3RyaW5nKHgpKTsKSnMubG9nKGVsZW1BcnJheSk7CkpzLmxvZyhSZWFjdC5hcnJheShlbGVtQXJyYXkpKTs%3D&live=off):
+playground](https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGVsZW1BcnJheTogYXJyYXkoUmVhY3QuZWxlbWVudCkgPQogICAgW3wiYSIsICJiIiwgImMifF0gfD4gSnMuQXJyYXkubWFwKH5mPXggPT4gUmVhY3Quc3RyaW5nKHgpKTsKSnMubG9nKGVsZW1BcnJheSk7CkpzLmxvZyhSZWFjdC5hcnJheShlbGVtQXJyYXkpKTs%3D&live=off):
 
 <<< Snippets.re#react-array-demo
 
@@ -288,7 +288,7 @@ styled with plain old CSS.
   function whose entire body is a switch expression
 - Labeled arguments in a component's `make` function are treated as props by
   ReasonReact.
-- The [Js.Array](https://melange.re/v3.0.0/api/re/melange/Js/Array/index.html)
+- The [Js.Array](https://melange.re/v4.0.0/api/re/melange/Js/Array/index.html)
   module contains useful array functions
   - The `Js.Array.reduce` function is the binding to JavaScript's `Array.reduce`
     method

--- a/docs/promo-codes/index.md
+++ b/docs/promo-codes/index.md
@@ -16,14 +16,14 @@ function:
 <<< Discount.re#simple-get-discount
 
 Instead of
-[Js.String.toUpperCase](https://melange.re/v3.0.0/api/re/melange/Js/String/#val-toLowerCase),
+[Js.String.toUpperCase](https://melange.re/v4.0.0/api/re/melange/Js/String/#val-toLowerCase),
 we could've used
-[String.uppercase_ascii](https://melange.re/v3.0.0/api/re/melange/Stdlib/String/#val-uppercase_ascii),
+[String.uppercase_ascii](https://melange.re/v4.0.0/api/re/melange/Stdlib/String/#val-uppercase_ascii),
 but as its name implies, `String.uppercase_ascii` can only handle strings
 containing ASCII characters. This is a common restriction for functions in the
-[Stdlib.String](https://melange.re/v3.0.0/api/re/melange/Stdlib/String/) module,
+[Stdlib.String](https://melange.re/v4.0.0/api/re/melange/Stdlib/String/) module,
 so for most string operations, you should prefer the functions in
-[Js.String](https://melange.re/v3.0.0/api/re/melange/Js/String/).
+[Js.String](https://melange.re/v4.0.0/api/re/melange/Js/String/).
 
 Madame Jellobutter informs you that the FREE promotion is only active during the
 month of May, so you change `Discount.getDiscountFunction` accordingly:
@@ -54,7 +54,7 @@ there's an error, but `Error` can signal **what the error is**.
 
 We don't need to type annotate anything when using the `Ok` and `Error`
 constructors because they are always in scope, due to the [result
-type](https://melange.re/v3.0.0/api/re/melange/Stdlib/#type-result) being
+type](https://melange.re/v4.0.0/api/re/melange/Stdlib/#type-result) being
 defined in `Stdlib` (which is open by default).
 
 :::
@@ -129,7 +129,7 @@ the value using `ignore`:
 <<< DiscountTests.re#ignore-list
 
 An even better solution would be to use
-[List.iter](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-iter):
+[List.iter](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-iter):
 
 <<< DiscountTests.re#list-iter{2}
 
@@ -390,7 +390,7 @@ correctly, so prefer to use the functions in `Js.String`
 ::: details Hint
 
 Use
-[List.init](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-init).
+[List.init](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-init).
 
 :::
 
@@ -428,9 +428,9 @@ encountered in the order.
 ::: details Hint 2
 
 Use
-[List.filter_map](https://melange.re/v3.0.0/api/re/melange/Stdlib/List/#val-filter_map)
+[List.filter_map](https://melange.re/v4.0.0/api/re/melange/Stdlib/List/#val-filter_map)
 and
-[ListLabels.fold_left](https://melange.re/v3.0.0/api/re/melange/Stdlib/ListLabels/#val-fold_left).
+[ListLabels.fold_left](https://melange.re/v4.0.0/api/re/melange/Stdlib/ListLabels/#val-fold_left).
 
 :::
 

--- a/docs/sandwich-tests/index.md
+++ b/docs/sandwich-tests/index.md
@@ -9,7 +9,7 @@ unit tests.
 ## Install `melange-fest` via opam
 
 After asking around in the `#melange` channel of the [Reason Discord
-chatroom](https://melange.re/v3.0.0/community.html#community), you get a
+chatroom](https://melange.re/v4.0.0/community.html#community), you get a
 recommendation from user MonadicFanatic1984 to try out
 [melange-fest](https://github.com/ahrefs/melange-fest), a library that allows
 you to write tests in OCaml and run them in [Node test
@@ -79,7 +79,7 @@ The output will look something like this:
 
 ```
 #  switch                     compiler                   description
-→  ~/melange-for-react-devs   ocaml-base-compiler.5.2.0  ~/melange-for-react-devs
+→  ~/melange-for-react-devs   ocaml-base-compiler.5.1.1  ~/melange-for-react-devs
    default                    ocaml.5.1.0                default
 
 [NOTE] Current switch has been selected based on the current directory.
@@ -331,10 +331,10 @@ date-dependent logic for Turducken sandwiches.
 ::: details Hint
 
 Use
-[Js.Date.makeWithYMD](https://melange.re/v3.0.0/api/re/melange/Js/Date/#val-makeWithYMD)
+[Js.Date.makeWithYMD](https://melange.re/v4.0.0/api/re/melange/Js/Date/#val-makeWithYMD)
 and `Js.Array.map` to generate a whole week's worth of dates. Here's a [relevant
 playground
-example](https://melange.re/v3.0.0/playground/?language=Reason&code=bGV0IGRhdGVzID0KICBbfDEuLCAyLiwgMy4sIDQuLCA1LiwgNi4sIDcufF0KICB8PiBKcy5BcnJheS5tYXAofmY9ZGF0ZSA9PgogICAgICAgSnMuRGF0ZS5tYWtlV2l0aFlNRCh%2BeWVhcj0yMDI0Liwgfm1vbnRoPTAuLCB%2BZGF0ZSkKICAgICApOwoKZGF0ZXMKfD4gSnMuQXJyYXkuZm9yRWFjaCh%2BZj1kYXRlID0%2BCiAgICAgSnMubG9nMihKcy5EYXRlLmdldERheShkYXRlKSwgSnMuRGF0ZS50b1N0cmluZyhkYXRlKSkKICAgKTsK&live=off).
+example](https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGRhdGVzID0KICBbfDEuLCAyLiwgMy4sIDQuLCA1LiwgNi4sIDcufF0KICB8PiBKcy5BcnJheS5tYXAofmY9ZGF0ZSA9PgogICAgICAgSnMuRGF0ZS5tYWtlV2l0aFlNRCh%2BeWVhcj0yMDI0Liwgfm1vbnRoPTAuLCB%2BZGF0ZSkKICAgICApOwoKZGF0ZXMKfD4gSnMuQXJyYXkuZm9yRWFjaCh%2BZj1kYXRlID0%2BCiAgICAgSnMubG9nMihKcy5EYXRlLmdldERheShkYXRlKSwgSnMuRGF0ZS50b1N0cmluZyhkYXRlKSkKICAgKTsK&live=off).
 
 :::
 

--- a/docs/sandwich-tests/index.md
+++ b/docs/sandwich-tests/index.md
@@ -44,7 +44,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "reason" {>= "3.10.0"}
   "dune" {>= "3.8"}
-  "melange" {>= "3.0.0-51"}
+  "melange" {>= "4.0.0-51"}
   "reason-react" {>= "0.14.0"}
   "reason-react-ppx" {>= "0.14.0"}
   "melange-fest" {>= "0.1.0"} // [!code ++]
@@ -79,7 +79,7 @@ The output will look something like this:
 
 ```
 #  switch                     compiler                   description
-→  ~/melange-for-react-devs   ocaml-base-compiler.5.1.1  ~/melange-for-react-devs
+→  ~/melange-for-react-devs   ocaml-base-compiler.5.2.0  ~/melange-for-react-devs
    default                    ocaml.5.1.0                default
 
 [NOTE] Current switch has been selected based on the current directory.

--- a/docs/styling-with-css/index.md
+++ b/docs/styling-with-css/index.md
@@ -17,7 +17,7 @@ Add a new file
 In OCaml, there is no syntax to import from files, because all modules within a
 project are visible to all other modules[^2]. However, we can make use of
 JavaScript's `import` syntax by using the [mel.raw extension
-node](https://melange.re/v3.0.0/communicate-with-javascript.html#generate-raw-javascript),
+node](https://melange.re/v4.0.0/communicate-with-javascript.html#generate-raw-javascript),
 which allows us to embed raw JavaScript in our OCaml code. Add the following
 line to the top of `Order.re`:
 
@@ -52,7 +52,7 @@ The problem is that Vite is serving the app from the build directory at
 `order-item.css` file isn't in that build directory.
 
 To solve this, we can add the [runtime_deps
-field](https://melange.re/v3.0.0/build-system.html#handling-assets) to our
+field](https://melange.re/v4.0.0/build-system.html#handling-assets) to our
 `melange.emit` stanza in `src/order-confirmation/dune`:
 
 ```dune{7}
@@ -117,7 +117,7 @@ Fortunately, Melange provides a more reliable way to import frontend assets.
 ## Import using `external`
 
 At the top of `Order.re`, replace our first `mel.raw` extension node with an
-[external](https://melange.re/v3.0.0/communicate-with-javascript.html#external-functions)
+[external](https://melange.re/v4.0.0/communicate-with-javascript.html#external-functions)
 declaration:
 
 ```reason
@@ -140,9 +140,9 @@ Let's break down the individual parts of the `external` declaration:
 [@mel.module "./order-item.css"] external _css: unit = "default";
 ```
 
-- [mel.module](https://melange.re/v3.0.0/communicate-with-javascript.html#using-functions-from-other-javascript-modules)
+- [mel.module](https://melange.re/v4.0.0/communicate-with-javascript.html#using-functions-from-other-javascript-modules)
   is an
-  [attribute](https://melange.re/v3.0.0/communicate-with-javascript.html#attributes)
+  [attribute](https://melange.re/v4.0.0/communicate-with-javascript.html#attributes)
   that tells the `external` declaration which module to import from
 - The `external` keyword tells OCaml this is a declaration for a value defined
   outside of OCaml, i.e. it comes from JavaScript[^4]
@@ -157,9 +157,9 @@ Let's break down the individual parts of the `external` declaration:
 ::: tip
 
 A quick way to check what an `external` declaration compiles to is to use
-the [Melange Playground](https://melange.re/v3.0.0/playground/). For example,
+the [Melange Playground](https://melange.re/v4.0.0/playground/). For example,
 here's a
-[link](https://melange.re/v3.0.0/playground/?language=Reason&code=W0BtZWwubW9kdWxlICIuL29yZGVyLWl0ZW0uY3NzIl0gZXh0ZXJuYWwgX2NzczogdW5pdCA9ICJkZWZhdWx0Ijs%3D&live=off)
+[link](https://melange.re/v4.0.0/playground/?language=Reason&code=W0BtZWwubW9kdWxlICIuL29yZGVyLWl0ZW0uY3NzIl0gZXh0ZXJuYWwgX2NzczogdW5pdCA9ICJkZWZhdWx0Ijs%3D&live=off)
 to the `external` declaration we just added.
 
 :::
@@ -202,7 +202,7 @@ inside the `OrderComponent` module, since that's the only place it's used.
 
 We have not seen the last of `external` declarations, as they are the primary
 way in which OCaml interacts with code written in JavaScript. See the [Melange
-docs](https://melange.re/v3.0.0/communicate-with-javascript.html#external-functions)
+docs](https://melange.re/v4.0.0/communicate-with-javascript.html#external-functions)
 for more details.
 
 ## Class names must be the same

--- a/melange-for-react-devs.opam
+++ b/melange-for-react-devs.opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "reason" {>= "3.10.0"}
   "dune" {>= "3.8"}
-  "melange" {>= "3.0.0-51"}
+  "melange" {>= "4.0.0-51"}
   "reason-react" {>= "0.14.0"}
   "reason-react-ppx" {>= "0.14.0"}
   "melange-fest" {>= "0.1.0"}


### PR DESCRIPTION
~~Going to wait for https://github.com/melange-re/melange-re.github.io to be updated before I change all the links from v3.0.0 to v4.0.0~~

- [x] Upgrade melange from 3.0.0-51 to 4.0.0-51
- [x] Update melange links from v3.0.0 to v4.0.0