### PR TITLE
Fix tests that break on Tuesdays

### DIFF
--- a/docs/burger-discounts/Discount.re
+++ b/docs/burger-discounts/Discount.re
@@ -271,3 +271,15 @@ let _ =
     Some(result);
     // #endregion return-variant-at-end
   };
+
+let _ =
+  name => {
+    // #region use-ok-some
+    name
+    |> String.split_on_char(' ')
+    |> List.map(String.map(c => c |> Char.code |> (+)(1) |> Char.chr))
+    |> String.concat(" ")
+    |> String.cat("Hello, ")
+    |> Option.some;
+                  // #endregion use-ok-some
+  };

--- a/docs/burger-discounts/DiscountTests.re
+++ b/docs/burger-discounts/DiscountTests.re
@@ -140,23 +140,25 @@ test("No burger has 1 of every topping, return None", () =>
      )
 );
 
-test("One burger has 1 of every topping, return Some(15.425)", () =>
+test("One burger has 1 of every topping, return Some", () => {
+  let items = [|
+    Item.Hotdog,
+    Sandwich(Portabello),
+    Burger({lettuce: true, tomatoes: true, cheese: 1, onions: 1, bacon: 1}),
+  |];
   expect
   |> equal(
-       Discount.getHalfOff([|
-         Hotdog,
-         Sandwich(Portabello),
-         Burger({
-           lettuce: true,
-           tomatoes: true,
-           cheese: 1,
-           onions: 1,
-           bacon: 1,
-         }),
-       |]),
-       Some(15.425),
-     )
-);
+       Discount.getHalfOff(items),
+       {
+         // Don't use hardcoded value since Item.toPrice is non-deterministic
+         let sum =
+           items
+           |> Js.Array.map(~f=Item.toPrice)
+           |> Js.Array.reduce(~init=0.0, ~f=(+.));
+         Some(sum /. 2.0);
+       },
+     );
+});
 // #endregion half-off-tests
 
 // #region new-half-off-tests
@@ -179,22 +181,24 @@ module HalfOff = {
        )
   );
 
-  test("One burger has 1+ of every topping, return Some(15.675)", () =>
+  test("One burger has 1+ of every topping, return Some", () => {
+    let items = [|
+      Item.Hotdog,
+      Sandwich(Portabello),
+      Burger({lettuce: true, tomatoes: true, cheese: 1, onions: 1, bacon: 2}),
+    |];
     expect
     |> equal(
-         Discount.getHalfOff([|
-           Hotdog,
-           Sandwich(Portabello),
-           Burger({
-             lettuce: true,
-             tomatoes: true,
-             cheese: 1,
-             onions: 1,
-             bacon: 1,
-           }),
-         |]),
-         Some(15.675),
-       )
-  );
+         Discount.getHalfOff(items),
+         {
+           // Don't use hardcoded value since Item.toPrice is non-deterministic
+           let sum =
+             items
+             |> Js.Array.map(~f=Item.toPrice)
+             |> Js.Array.reduce(~init=0.0, ~f=(+.));
+           Some(sum /. 2.0);
+         },
+       );
+  });
 };
 // #endregion new-half-off-tests

--- a/docs/burger-discounts/index.md
+++ b/docs/burger-discounts/index.md
@@ -409,14 +409,19 @@ Error This expression should not be a constructor, the expected type is int -> '
 ```
 
 Variant constructors like `Some` are not functions, so they can't be used with
-the pipe last (`|>`) operator. If you have have a long chain of function
-invocations but you need to return a variant at the end, consider using an extra
-variable, e.g.
+the pipe last (`|>`) operator. If you have a long chain of function invocations
+but you need to return a variant at the end, consider using an extra variable,
+e.g.
 
 <<< Discount.re#return-variant-at-end
 
 See [full example on Melange
 Playground](https://melange.re/v4.0.0/playground/?language=Reason&code=bGV0IGNpcGhlckdyZWV0aW5nID0gbmFtZSA9PiB7CiAgc3dpdGNoIChTdHJpbmcudHJpbShuYW1lKSkgewogIHwgIiIgPT4gTm9uZQogIHwgbmFtZSA9PgogICAgbGV0IHJlc3VsdCA9CiAgICAgIG5hbWUKICAgICAgfD4gU3RyaW5nLnNwbGl0X29uX2NoYXIoJyAnKQogICAgICB8PiBMaXN0Lm1hcChTdHJpbmcubWFwKGMgPT4gYyB8PiBDaGFyLmNvZGUgfD4gKCspKDEpIHw%2BIENoYXIuY2hyKSkKICAgICAgfD4gU3RyaW5nLmNvbmNhdCgiICIpCiAgICAgIHw%2BIFN0cmluZy5jYXQoIkhlbGxvLCAiKTsKCiAgICBTb21lKHJlc3VsdCk7CiAgfTsKfTsKCkpzLmxvZyhjaXBoZXJHcmVldGluZygiIikpOwpKcy5sb2coY2lwaGVyR3JlZXRpbmcoIlhhdmllciBMZXJveSIpKTsK&live=off).
+
+When the variant type you're using is `option`, though, you can still chain
+functions by using the `Option.some` helper function:
+
+<<< Discount.re#use-ok-some
 
 ---
 

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -41,6 +41,7 @@ teaches the language from the ground up and goes much deeper into its features.
 | Cram Tests | Set up cram tests to run your unit tests | cram tests, `cram` stanza, Dune alias, promotion, test output sanitization, sandbox, `expand_aliases_in_sandbox` stanza |
 | Burger Discounts | Implement burger discount logic using arrays | limits of type inference, type annotation of function arguments, full name (asset path), `Stdlib`, record spread syntax, `ignore`, runtime representations of common data types, properties of arrays, override `Array.get` |
 | Discounts Using Lists | Re-implement burger discount logic using lists | properties of lists, pattern matching on lists, list spread syntax, `List` module, `ListLabels` module, runtime representation of lists, documentation comments, placeholder operator |
+| Promo Codes | Implement promo and discount logic using Result | built-in Result type, translating error message to Reason syntax, `List.iter`, for  loops, polymorphic variants, runtime representations of Result and polymorphic variants |
 
 ...and much more to come!
 

--- a/docs/promo-codes/DiscountTests.re
+++ b/docs/promo-codes/DiscountTests.re
@@ -125,26 +125,32 @@ test("FREE promo code works in May but not other months", () => {
          )
     );
 
-    test("All sandwiches, return Ok", () =>
+    test("All sandwiches, return Ok", () => {
+      let items = [
+        Item.Sandwich(Turducken),
+        Hotdog,
+        Sandwich(Portabello),
+        Burger({
+          lettuce: true,
+          tomatoes: true,
+          cheese: 1,
+          onions: 1,
+          bacon: 2,
+        }),
+        Sandwich(Unicorn),
+        Sandwich(Ham),
+      ];
       expect
       |> deepEqual(
-           Discount.getSandwichHalfOff([
-             Sandwich(Turducken),
-             Hotdog,
-             Sandwich(Portabello),
-             Burger({
-               lettuce: true,
-               tomatoes: true,
-               cheese: 1,
-               onions: 1,
-               bacon: 2,
-             }),
-             Sandwich(Unicorn),
-             Sandwich(Ham),
-           ]),
-           Ok(70.675),
-         )
-    );
+           Discount.getSandwichHalfOff(items),
+           {
+             // Don't use hardcoded value since Item.toPrice is non-deterministic
+             let sum =
+               items |> List.map(Item.toPrice) |> List.fold_left((+.), 0.0);
+             Ok(sum /. 2.0);
+           },
+         );
+    });
   };
   // #endregion get-sandwich-half-off
 

--- a/docs/promo-codes/index.md
+++ b/docs/promo-codes/index.md
@@ -2,11 +2,11 @@
 
 As International Burger Day looms ever closer, Madame Jellobutter is eager to
 start her burger-related promotions. She bought ads on local billboards and she
-even wore a giant burger costume to pass flyers at a local music festival[^1].
-Depending on the ad, potential customers will either see the promo code FREE,
-which corresponds to the "buy n burgers, get n/2 burgers free" discount, or
-HALF, which corresponds to the "buy a burger with everything on it and get half
-off the entire order" discount.
+even wore a giant burger costume to pass out flyers at a local music
+festival[^1]. Depending on the ad, potential customers will either see the promo
+code FREE, which corresponds to the "buy n burgers, get n/2 burgers free"
+discount, or HALF, which corresponds to the "buy a burger with everything on it
+and get half off the entire order" discount.
 
 ## `getDiscountFunction` function
 

--- a/src/burger-discounts/DiscountTests.re
+++ b/src/burger-discounts/DiscountTests.re
@@ -111,21 +111,23 @@ module HalfOff = {
        )
   );
 
-  test("One burger has 1+ of every topping, return Some(15.675)", () =>
+  test("One burger has 1+ of every topping, return Some", () => {
+    let items = [|
+      Item.Hotdog,
+      Sandwich(Portabello),
+      Burger({lettuce: true, tomatoes: true, cheese: 1, onions: 1, bacon: 2}),
+    |];
     expect
     |> equal(
-         Discount.getHalfOff([|
-           Hotdog,
-           Sandwich(Portabello),
-           Burger({
-             lettuce: true,
-             tomatoes: true,
-             cheese: 1,
-             onions: 1,
-             bacon: 2,
-           }),
-         |]),
-         Some(15.675),
-       )
-  );
+         Discount.getHalfOff(items),
+         {
+           // Don't use hardcoded value since Item.toPrice is non-deterministic
+           let sum =
+             items
+             |> Js.Array.map(~f=Item.toPrice)
+             |> Js.Array.reduce(~init=0.0, ~f=(+.));
+           Some(sum /. 2.0);
+         },
+       );
+  });
 };

--- a/src/burger-discounts/tests.t
+++ b/src/burger-discounts/tests.t
@@ -85,8 +85,8 @@ Discount tests
   ok 7 - No burger has 1+ of every topping, return None
     ---
     ...
-  # Subtest: One burger has 1+ of every topping, return Some(15.675)
-  ok 8 - One burger has 1+ of every topping, return Some(15.675)
+  # Subtest: One burger has 1+ of every topping, return Some
+  ok 8 - One burger has 1+ of every topping, return Some
     ---
     ...
   1..8

--- a/src/discounts-lists/DiscountTests.re
+++ b/src/discounts-lists/DiscountTests.re
@@ -109,21 +109,21 @@ module HalfOff = {
        )
   );
 
-  test("One burger has 1+ of every topping, return Some(15.675)", () =>
+  test("One burger has 1+ of every topping, return Some", () => {
+    let items = [
+      Item.Hotdog,
+      Sandwich(Portabello),
+      Burger({lettuce: true, tomatoes: true, cheese: 1, onions: 1, bacon: 2}),
+    ];
     expect
     |> equal(
-         Discount.getHalfOff([
-           Hotdog,
-           Sandwich(Portabello),
-           Burger({
-             lettuce: true,
-             tomatoes: true,
-             cheese: 1,
-             onions: 1,
-             bacon: 2,
-           }),
-         ]),
-         Some(15.675),
-       )
-  );
+         Discount.getHalfOff(items),
+         {
+           // Don't use hardcoded value since Item.toPrice is non-deterministic
+           let sum =
+             items |> List.map(Item.toPrice) |> List.fold_left((+.), 0.0);
+           Some(sum /. 2.0);
+         },
+       );
+  });
 };

--- a/src/discounts-lists/tests.t
+++ b/src/discounts-lists/tests.t
@@ -85,8 +85,8 @@ Discount tests
   ok 7 - No burger has 1+ of every topping, return None
     ---
     ...
-  # Subtest: One burger has 1+ of every topping, return Some(15.675)
-  ok 8 - One burger has 1+ of every topping, return Some(15.675)
+  # Subtest: One burger has 1+ of every topping, return Some
+  ok 8 - One burger has 1+ of every topping, return Some
     ---
     ...
   1..8

--- a/src/promo-codes/DiscountTests.re
+++ b/src/promo-codes/DiscountTests.re
@@ -109,23 +109,23 @@ module HalfOff = {
        )
   );
 
-  test("One burger has 1+ of every topping, return Ok(15.675)", () =>
+  test("One burger has 1+ of every topping, return Ok", () => {
+    let items = [
+      Item.Hotdog,
+      Sandwich(Portabello),
+      Burger({lettuce: true, tomatoes: true, cheese: 1, onions: 1, bacon: 2}),
+    ];
     expect
     |> deepEqual(
-         Discount.getHalfOff([
-           Hotdog,
-           Sandwich(Portabello),
-           Burger({
-             lettuce: true,
-             tomatoes: true,
-             cheese: 1,
-             onions: 1,
-             bacon: 2,
-           }),
-         ]),
-         Ok(15.675),
-       )
-  );
+         Discount.getHalfOff(items),
+         {
+           // Don't use hardcoded value since Item.toPrice is non-deterministic
+           let sum =
+             items |> List.map(Item.toPrice) |> List.fold_left((+.), 0.0);
+           Ok(sum /. 2.0);
+         },
+       );
+  });
 };
 
 module SandwichHalfOff = {
@@ -142,26 +142,26 @@ module SandwichHalfOff = {
        )
   );
 
-  test("All sandwiches, return Ok", () =>
+  test("All sandwiches, return Ok", () => {
+    let items = [
+      Item.Sandwich(Turducken),
+      Hotdog,
+      Sandwich(Portabello),
+      Burger({lettuce: true, tomatoes: true, cheese: 1, onions: 1, bacon: 2}),
+      Sandwich(Unicorn),
+      Sandwich(Ham),
+    ];
     expect
     |> deepEqual(
-         Discount.getSandwichHalfOff([
-           Sandwich(Turducken),
-           Hotdog,
-           Sandwich(Portabello),
-           Burger({
-             lettuce: true,
-             tomatoes: true,
-             cheese: 1,
-             onions: 1,
-             bacon: 2,
-           }),
-           Sandwich(Unicorn),
-           Sandwich(Ham),
-         ]),
-         Ok(70.675),
-       )
-  );
+         Discount.getSandwichHalfOff(items),
+         {
+           // Don't use hardcoded value since Item.toPrice is non-deterministic
+           let sum =
+             items |> List.map(Item.toPrice) |> List.fold_left((+.), 0.0);
+           Ok(sum /. 2.0);
+         },
+       );
+  });
 };
 
 module GetDiscount = {

--- a/src/promo-codes/tests.t
+++ b/src/promo-codes/tests.t
@@ -85,8 +85,8 @@ Discount tests
   ok 7 - No burger has 1+ of every topping, return Error(`NeedMegaBurger)
     ---
     ...
-  # Subtest: One burger has 1+ of every topping, return Ok(15.675)
-  ok 8 - One burger has 1+ of every topping, return Ok(15.675)
+  # Subtest: One burger has 1+ of every topping, return Ok
+  ok 8 - One burger has 1+ of every topping, return Ok
     ---
     ...
   # Subtest: Not all sandwiches, return Error


### PR DESCRIPTION
- [x] Mention `Ok.some` as a way to chain functions when final value is option
- [x] Add promo codes chapter to chapters & topics table
- [x] Make tests that use `Item.toPrice` not break on Tuesday

There's a better way to fix the broken test issue, which is to just add a `~date` argument to `Item.toPrice`. But I couldn't quite justify changing it in earlier chapters because I wanted to keep the related code simple. I'll try to add it as an exercise in the next chapter.