### PR TITLE
remove underlines from patterns in code blocks

### DIFF
--- a/docs/syntaxes/reason.json
+++ b/docs/syntaxes/reason.json
@@ -975,7 +975,7 @@
             "2": { "name": "comment" },
             "3": { "name": "comment" },
             "4": {
-              "name": "variable.parameter string.other.link variable.language"
+              "name": "variable.parameter variable.language"
             }
           }
         }
@@ -1017,7 +1017,7 @@
             },
             "2": { "name": "comment" },
             "3": {
-              "name": "variable.parameter string.other.link variable.language"
+              "name": "variable.parameter variable.language"
             }
           }
         },
@@ -1217,7 +1217,7 @@
               "match": "\\b([[:lower:]][[:word:]]*)\\b[[:space:]]*",
               "captures": {
                 "1": {
-                  "name": "variable.parameter string.other.link variable.language"
+                  "name": "variable.parameter variable.language"
                 }
               }
             },
@@ -1279,7 +1279,7 @@
         {
           "match": "\\b([[:lower:]][[:word:]]*)\\b(?!\\.[[:upper:]])",
           "captures": {
-            "1": { "name": "variable.language string.other.link" }
+            "1": { "name": "variable.language" }
           }
         }
       ]
@@ -1710,7 +1710,7 @@
       "captures": {
         "1": { "name": "comment" },
         "2": {
-          "name": "variable.parameter string.other.link variable.language"
+          "name": "variable.parameter variable.language"
         }
       }
     },
@@ -2107,7 +2107,7 @@
               "name": "entity.other.attribute-name.css constant.language constant.numeric"
             },
             "2": {
-              "name": "variable.other.readwrite.instance string.other.link variable.language"
+              "name": "variable.other.readwrite.instance variable.language"
             }
           }
         }


### PR DESCRIPTION
This took a while. Before, patterns would render like this:

<img width="711" alt="image" src="https://github.com/user-attachments/assets/0f879f89-8498-4663-b402-b218a2f4048e">

See how `root` pattern is underlined.

The `reason` textmate grammar was using some rules called `string.other.link`. These rules are set to render underlines in the [github-dark](https://github.com/shikijs/textmate-grammars-themes/blob/182d5367e4c3a6ea393dd2dc8ce1a59561e7aa7e/packages/tm-themes/themes/github-dark.json#L535) and [github-light](https://github.com/shikijs/textmate-grammars-themes/blob/182d5367e4c3a6ea393dd2dc8ce1a59561e7aa7e/packages/tm-themes/themes/github-light.json#L534) shiki themes, which is what vitepress use as default.

After this change:

<img width="706" alt="image" src="https://github.com/user-attachments/assets/c7a5e8eb-f10a-4776-9fad-26bda8efefb2">
