### PR TITLE
docs: correct vite default port to 5173

### DIFF
--- a/docs/counter/index.md
+++ b/docs/counter/index.md
@@ -10,8 +10,8 @@ project
 1. Run `npm run watch` to start the Melange compiler in watch mode.
 1. In another terminal window, start the Vite dev server by running `npm run
 serve`. As a side effect, it will open a browser tab pointed to
-<a href="http://localhost:5174/" target="_blank" rel="noreferrer
-noopener">http://localhost:5174/</a>.
+<a href="http://localhost:5173/" target="_blank" rel="noreferrer
+noopener">http://localhost:5173/</a>.
 
 ## The `App` component
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -86,8 +86,8 @@ npm run serve
 While `npm run init` is running, consider grabbing some coffee or other
 beverage, as it might take a while to fetch all the dependencies and build them.
 The last command, `npm run serve`, should open a tab in your default browser which
-points to <a href="http://localhost:5174/" target="_blank" rel="noreferrer
-noopener">http://localhost:5174/</a> and shows you a typical "Hello World" page.
+points to <a href="http://localhost:5173/" target="_blank" rel="noreferrer
+noopener">http://localhost:5173/</a> and shows you a typical "Hello World" page.
 If you see this page, then the project was successfully installed!
 
 ## Visual Studio Code Extension


### PR DESCRIPTION
When running `npm run serve`, vite uses the default port `5173` (unless that port is already taken).
The documentation currently references `http://localhost:5174`, which leads to broken links when following the tutorial.